### PR TITLE
Load WooCommerce API config from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/README.md
+++ b/README.md
@@ -72,3 +72,19 @@ If you are looking for a high-quality free admin template that comes with all es
 - Updated to Bootstrap 5.1.1
 - Fixed minor bugs
 - Enhanced the UI and Improved Typography
+
+## Environment Configuration
+
+The PHP scripts under `assets/cPhp` expect three environment variables to be present:
+
+- `WOOCOMMERCE_CK` – WooCommerce consumer key
+- `WOOCOMMERCE_CS` – WooCommerce consumer secret
+- `STORE_URL` – URL of your WooCommerce store
+
+Create a `.env` file in the project root containing these variables and export them in your server environment before running the application:
+
+```bash
+WOOCOMMERCE_CK=your_key
+WOOCOMMERCE_CS=your_secret
+STORE_URL=https://example.com
+```

--- a/assets/cPhp/master-api.php
+++ b/assets/cPhp/master-api.php
@@ -2,9 +2,12 @@
 // master-api.php
 include_once(__DIR__ . '/server-config.php');
 
-// WooCommerce REST API Credentials  
-$consumer_key    = 'ck_599f2b3ebf95fe43c9ec032de08ebb1e1b10428a';
-$consumer_secret = 'cs_f781a6ecf0d14294b126954a2e15428930b1ac29';
-// Change store_url to point to the live site:
-$store_url       = 'https://tharavix.com';
+// WooCommerce REST API Credentials loaded from environment variables
+$consumer_key    = getenv('WOOCOMMERCE_CK');
+$consumer_secret = getenv('WOOCOMMERCE_CS');
+$store_url       = getenv('STORE_URL');
+
+if (!$consumer_key || !$consumer_secret || !$store_url) {
+    die('Environment variables WOOCOMMERCE_CK, WOOCOMMERCE_CS and STORE_URL must be set.');
+}
 ?>


### PR DESCRIPTION
## Summary
- ignore `.env` and document environment variables
- load WooCommerce credentials from environment in `master-api.php`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd1ef2cc4832faf0ebb1b0d6a6468