### PR TITLE
Fix refunded orders API endpoint

### DIFF
--- a/assets/cPhp/get_refunded_orders.php
+++ b/assets/cPhp/get_refunded_orders.php
@@ -1,7 +1,7 @@
 <?php
-// get_pending_orders.php
+// get_refunded_orders.php
 //
-// Fetches WooCommerce orders with status=processing ("New Orders")
+// Fetches WooCommerce orders with status=refunded ("Refunded Orders")
 // and re-emits the X-My-TotalPages header so JS can paginate correctly.
 
 require_once(__DIR__ . '/master-api.php'); // loads $store_url, $consumer_key, $consumer_secret
@@ -43,7 +43,7 @@ $page     = isset($_GET['page'])     ? (int) $_GET['page']     : 1;
 $per_page = isset($_GET['per_page']) ? (int) $_GET['per_page'] : 20;
 
 // API call
-$endpoint = "/wp-json/wc/v3/orders?status=pending&page={$page}&per_page={$per_page}";
+$endpoint = "/wp-json/wc/v3/orders?status=refunded&page={$page}&per_page={$per_page}";
 
 header('Content-Type: application/json; charset=utf-8');
 echo callWooAPI(


### PR DESCRIPTION
## Summary
- update header comment for refunded orders
- point refunded orders API to `status=refunded`

## Testing
- `php -l assets/cPhp/get_refunded_orders.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd5887ddc832f8ca57f5d0abaeb58