### PR TITLE
Add product edit modal logic

### DIFF
--- a/assets/cPhp/get_product.php
+++ b/assets/cPhp/get_product.php
@@ -1,0 +1,33 @@
+<?php
+require_once __DIR__ . '/master-api.php';
+
+function callWooAPI($baseUrl, $endpoint, $ck, $cs) {
+    $url = rtrim($baseUrl, '/') . $endpoint;
+    $ch  = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Authorization: Basic ' . base64_encode("$ck:$cs"),
+        'Content-Type: application/json'
+    ]);
+    $resp = curl_exec($ch);
+    if (curl_errno($ch)) {
+        http_response_code(500);
+        echo json_encode(['error' => curl_error($ch)]);
+        exit;
+    }
+    curl_close($ch);
+    return $resp;
+}
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if (!$id) {
+    http_response_code(400);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['error' => 'Missing product ID']);
+    exit;
+}
+
+header('Content-Type: application/json; charset=utf-8');
+echo callWooAPI($store_url, "/wp-json/wc/v3/products/{$id}", $consumer_key, $consumer_secret);
+exit;
+?>

--- a/assets/js/cJs/product-management.js
+++ b/assets/js/cJs/product-management.js
@@ -100,8 +100,46 @@ function updateUrl(page) {
 // --------------------------------------------------------------------------------
 window.fetchPendingOrders = fetchProducts;
 
-// — Modal logic stays unchanged —
+// — Modal logic —
 $(document).on('click', '.edit-btn', function() {
-  /* …open + populate modal… */
+  const id = $(this).data('id');
+  $.getJSON(`${BASE_URL}/assets/cPhp/get_product.php`, { id })
+    .done(p => {
+      $('#edit-id').val(p.id);
+      $('#edit-name').val(p.name);
+      $('#edit-price').val(p.price || p.regular_price || '');
+      $('#edit-stock').val(p.stock_quantity ?? '');
+      $('#edit-status').val(p.stock_status || 'instock');
+      new bootstrap.Modal($('#editProductModal')).show();
+    })
+    .fail(xhr => {
+      console.error('Product load failed:', xhr.responseText);
+      alert('Failed to load product information');
+    });
 });
-$('#editProductForm').submit(function(e){ /* …save product…*/ });
+
+$('#editProductForm').submit(function(e){
+  e.preventDefault();
+  const payload = {
+    id:    $('#edit-id').val(),
+    price: $('#edit-price').val(),
+    stock: $('#edit-stock').val(),
+    status: $('#edit-status').val()
+  };
+
+  $.ajax({
+    url: `${BASE_URL}/assets/cPhp/update_product.php`,
+    method: 'POST',
+    contentType: 'application/json',
+    dataType: 'json',
+    data: JSON.stringify(payload)
+  })
+  .done(() => {
+    bootstrap.Modal.getInstance($('#editProductModal')[0]).hide();
+    fetchProducts(currentPage);
+  })
+  .fail(xhr => {
+    console.error('Update failed:', xhr.responseText);
+    alert('Failed to update product');
+  });
+});


### PR DESCRIPTION
## Summary
- create API endpoint to fetch a single product
- implement edit modal logic in product-management JS

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fd58a3630832fa5e4ec3e8acc12c8