### PR TITLE
Add notifications list to dashboard

### DIFF
--- a/assets/js/cJs/dashboard.js
+++ b/assets/js/cJs/dashboard.js
@@ -8,6 +8,21 @@ $(function() {
     $('#box-low-stock').text(data.low_stock);
     $('#box-revenue').text(`AED ${data.revenue.toFixed(2)}`);
 
+    // Render notifications list
+    function renderNotifications(list) {
+      const $n = $('#notif-list').empty();
+      (list || []).forEach(n => {
+        $n.append(`
+          <li class="list-group-item">
+            <a href="${n.link}">${n.message}</a>
+          </li>
+        `);
+      });
+    }
+
+    // Initial notifications
+    renderNotifications(data.notifications);
+
     // Function to render Top 10 list
     function renderTop(list) {
       const $b = $('#top-body').empty();

--- a/index.php
+++ b/index.php
@@ -138,6 +138,13 @@
               </table>
             </div>
           </div>
+          <!-- Notifications -->
+          <div class="card-style mb-30">
+            <h6 class="text-medium mb-25">Notifications</h6>
+            <ul id="notif-list" class="list-group list-group-flush">
+              <!-- injected by JS -->
+            </ul>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- extend dashboard.js to render notifications returned by the dashboard API
- show a Notifications card on the dashboard page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fd58a89f0832fa390fdefc39f38e7