### PR TITLE
Fix meta tag hyphen

### DIFF
--- a/new-orders.php
+++ b/new-orders.php
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8"/>
-    <meta http‑equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <link rel="shortcut icon" href="assets/images/favicon.svg" type="image/x-icon"/>
     <title>Tharavix | New Orders</title>


### PR DESCRIPTION
## Summary
- fix unicode hyphen in `http-equiv` attribute on new orders page
- verify meta tags are readable by HTML parser

## Testing
- `python3 - <<'PY'
from html.parser import HTMLParser
class P(HTMLParser):
    def handle_starttag(self,t,attrs):
        attrs=dict(attrs)
        if t=='meta' and attrs.get('http-equiv'):
            print('META', attrs['http-equiv'], attrs.get('content'))

with open('new-orders.php') as f:
    P().feed(f.read())
PY`
- `python3 - <<'PY'
from html.parser import HTMLParser
class P(HTMLParser):
    def __init__(self,name):
        super().__init__()
        self.name=name
    def handle_starttag(self,t,attrs):
        attrs=dict(attrs)
        if t=='meta' and attrs.get('http-equiv'):
            print(self.name, attrs['http-equiv'], attrs.get('content'))

for f in ['new-orders.php','index.php']:
    with open(f) as fh:
        P(f).feed(fh.read())
PY`

------
https://chatgpt.com/codex/tasks/task_e_683fd614a7fc832f878e710ed7d2e5c1