### PR TITLE
Add Jest testing for pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,12 @@ WOOCOMMERCE_CK=your_key
 WOOCOMMERCE_CS=your_secret
 STORE_URL=https://example.com
 ```
+
+## Running Tests
+
+Install dependencies and run the test suite:
+
+```bash
+npm install
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "gulp": "^4.0.2",
     "gulp-minify": "^3.1.0",
     "gulp-sass": "^5.1.0",
-    "sass": "^1.63.6"
+    "sass": "^1.63.6",
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }

--- a/tests/pagination.test.js
+++ b/tests/pagination.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const jquery = require('jquery');
+
+let script;
+
+beforeAll(() => {
+  script = fs.readFileSync(path.resolve(__dirname, '../assets/js/cJs/pagination.js'), 'utf8');
+});
+
+beforeEach(() => {
+  // Jest uses jsdom environment by default
+  global.$ = jquery(global.window);
+  document.body.innerHTML = '<ul class="base-pagination pagination"></ul>';
+  vm.runInThisContext(script);
+});
+
+afterEach(() => {
+  delete global.$;
+  delete global.buildPagination;
+  delete global.currentPage;
+  delete global.totalPages;
+});
+
+test('generates expected number of pagination links', () => {
+  global.currentPage = 2;
+  global.totalPages = 5;
+  buildPagination();
+  const items = document.querySelectorAll('.base-pagination.pagination li');
+  expect(items.length).toBe(7); // prev + pages + next
+});


### PR DESCRIPTION
## Summary
- install Jest and jsdom dev dependencies
- add pagination unit test
- document how to run `npm test`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd61750a8832f8d1fbc0e74d5bb87