### PR TITLE
Clean up comments in refunded orders API

### DIFF
--- a/assets/cPhp/get_refunded_orders.php
+++ b/assets/cPhp/get_refunded_orders.php
@@ -1,11 +1,8 @@
 <?php
 // get_refunded_orders.php
 //
- codex/update-comments-in-php-scripts
-// Fetches WooCommerce orders with status=pending
 
 // Fetches WooCommerce orders with status=refunded ("Refunded Orders")
- main
 // and re-emits the X-My-TotalPages header so JS can paginate correctly.
 
 require_once(__DIR__ . '/master-api.php'); // loads $store_url, $consumer_key, $consumer_secret


### PR DESCRIPTION
## Summary
- tidy up beginning of refunded orders PHP script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd8dd6840832fb95b7e0cf94c4b51