### PR TITLE
Add 17track status polling

### DIFF
--- a/assets/cPhp/update_tracking.php
+++ b/assets/cPhp/update_tracking.php
@@ -1,0 +1,136 @@
+<?php
+// assets/cPhp/update_tracking.php
+// Query the 17track API for shipment updates and optionally
+// update WooCommerce order statuses.
+
+require_once __DIR__ . '/master-api.php';
+
+$apiKey = getenv('TRACK17_APIKEY');
+if (!$apiKey) {
+    http_response_code(500);
+    echo json_encode(['error' => 'TRACK17_APIKEY not set']);
+    exit;
+}
+
+/**
+ * Helper to call WooCommerce API
+ */
+function wooRequest($endpoint, $method = 'GET', $data = null) {
+    global $store_url, $consumer_key, $consumer_secret;
+    $url = rtrim($store_url, '/') . $endpoint;
+    $ch  = curl_init($url);
+
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_USERPWD, "$consumer_key:$consumer_secret");
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+
+    if ($method !== 'GET') {
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        if ($data !== null) {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+        }
+    }
+
+    $resp = curl_exec($ch);
+    $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    return [$code, json_decode($resp, true)];
+}
+
+/**
+ * Call the 17track realtime API.
+ */
+function call17Track($carrier, $number, $apiKey) {
+    $payload = ['number' => $number];
+    if (!empty($carrier)) {
+        $payload['carrier'] = $carrier;
+    }
+
+    $ch = curl_init('https://api.17track.net/track/v2/realtime');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        '17token: ' . $apiKey,
+        'Content-Type: application/json'
+    ]);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));
+
+    $resp = curl_exec($ch);
+    if (curl_errno($ch)) {
+        curl_close($ch);
+        return null;
+    }
+
+    curl_close($ch);
+    return json_decode($resp, true);
+}
+
+/**
+ * Extract a simplified event from the 17track response.
+ */
+function parseEvent($res) {
+    if (!is_array($res)) return [null, null, null, null];
+
+    $data = $res['data'][0] ?? [];
+    $status = $data['status'] ?? '';
+    $event  = $data['last_event'] ?? '';
+    $time   = $data['last_event_time'] ?? '';
+
+    $type = null;
+    $low  = strtolower($event);
+    if (strpos($low, 'customs') !== false) {
+        $type = 'customs_hold';
+    } elseif (strpos($low, 'delivered') !== false || strtolower($status) === 'delivered') {
+        $type = 'delivered';
+    } elseif (strpos($low, 'exception') !== false) {
+        $type = 'exception';
+    }
+
+    return [$type, $status, $time, $event];
+}
+
+// ---------------------------------------------------------------------
+// 1) Get all in-transit orders with tracking numbers
+$orders = [];
+$page = 1;
+while (true) {
+    list($code, $batch) = wooRequest("/wp-json/wc/v3/orders?status=in-transit&per_page=100&page={$page}");
+    if ($code !== 200 || empty($batch)) {
+        break;
+    }
+    $orders = array_merge($orders, $batch);
+    $page++;
+}
+
+$events = [];
+foreach ($orders as $o) {
+    $carrier = $number = '';
+    foreach ($o['meta_data'] as $m) {
+        if ($m['key'] === '_wot_tracking_carrier') $carrier = $m['value'];
+        if ($m['key'] === '_wot_tracking_number')  $number  = $m['value'];
+    }
+    if ($number === '') continue;
+
+    $result = call17Track($carrier, $number, $apiKey);
+    list($type, $status, $time, $desc) = parseEvent($result);
+    if ($type === null) continue;
+
+    // Update order status when delivered
+    if ($type === 'delivered') {
+        wooRequest("/wp-json/wc/v3/orders/{$o['id']}", 'PUT', ['status' => 'delivered']);
+    }
+
+    $events[] = [
+        'order_id'   => $o['id'],
+        'event_type' => $type,
+        'status'     => $status,
+        'timestamp'  => $time,
+        'description'=> $desc
+    ];
+}
+
+header('Content-Type: application/json; charset=utf-8');
+echo json_encode($events);
+exit;
+?>

--- a/assets/js/cJs/dashboard.js
+++ b/assets/js/cJs/dashboard.js
@@ -8,7 +8,6 @@ $(function() {
     $('#box-low-stock').text(data.low_stock);
     $('#box-revenue').text(`AED ${data.revenue.toFixed(2)}`);
 
-    // Render notifications list
     function renderNotifications(list) {
       const $n = $('#notif-list').empty();
       (list || []).forEach(n => {
@@ -20,10 +19,23 @@ $(function() {
       });
     }
 
-    // Initial notifications
     renderNotifications(data.notifications);
 
-    // Function to render Top 10 list
+    function fetchTrackingNotifications() {
+      $.getJSON(`${BASE_URL}/assets/cPhp/update_tracking.php`, evs => {
+        if (Array.isArray(evs) && evs.length) {
+          const list = evs.map(e => ({
+            message: `Order #${e.order_id}: ${e.event_type}`,
+            link: `/shipments.php?order_id=${e.order_id}`
+          })).concat(data.notifications);
+          renderNotifications(list);
+        }
+      });
+    }
+
+    fetchTrackingNotifications();
+    setInterval(fetchTrackingNotifications, 300000);
+
     function renderTop(list) {
       const $b = $('#top-body').empty();
       (list || []).slice(0,10).forEach((item, i) => {
@@ -46,10 +58,8 @@ $(function() {
       });
     }
 
-    // Initial load (yearly)
     renderTop(data.top_sellers_yearly || data.top_sellers);
 
-    // Toggle Yearly/Monthly
     $('#top-range').on('change', function() {
       const list = (this.value === 'monthly'
         ? (data.top_sellers_monthly || data.top_sellers)

--- a/assets/js/cJs/shipments.js
+++ b/assets/js/cJs/shipments.js
@@ -99,3 +99,23 @@ function updateUrl(page) {
   const newUrl = `${window.location.pathname}?page=${page}`;
   window.history.replaceState({}, '', newUrl);
 }
+
+/**
+ * Periodically check 17track for status updates
+ */
+function checkTrackingUpdates() {
+  $.getJSON(`${BASE_URL}/assets/cPhp/update_tracking.php`, events => {
+    events.forEach(ev => {
+      const $row = $(`#shipmentsTable tbody tr[data-order-id="${ev.order_id}"]`);
+      if ($row.length) {
+        $row.find('td').eq(4).text(ev.status);
+        $row.find('td').eq(5).text(ev.timestamp || '');
+      }
+    });
+  });
+}
+
+$(function(){
+  checkTrackingUpdates();
+  setInterval(checkTrackingUpdates, 300000); // every 5 minutes
+});


### PR DESCRIPTION
## Summary
- add `update_tracking.php` to poll the 17track API and update WooCommerce
- periodically poll tracking API from `shipments.js`
- surface shipment events on the dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd8de0c88832faed1ae2ab62200c1