### PR TITLE
Add refund dashboard

### DIFF
--- a/assets/cPhp/get_refund_requests.php
+++ b/assets/cPhp/get_refund_requests.php
@@ -1,0 +1,24 @@
+<?php
+// assets/cPhp/get_refund_requests.php
+// Return a list of refund requests for the refund dashboard.
+// In production this would pull from WooCommerce or a database.
+// For this demo we read a local JSON file under uploads/.
+
+header('Content-Type: application/json; charset=utf-8');
+
+$file = __DIR__ . '/../uploads/refund_requests.json';
+if (!file_exists($file)) {
+    echo json_encode([]);
+    exit;
+}
+
+$raw = file_get_contents($file);
+if ($raw === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to read data']);
+    exit;
+}
+
+echo $raw;
+exit;
+?>

--- a/assets/js/cJs/refund_requests.js
+++ b/assets/js/cJs/refund_requests.js
@@ -1,0 +1,57 @@
+// assets/js/cJs/refund_requests.js
+
+let currentPage = 1,
+    totalPages  = 1,
+    PER_PAGE    = 20;
+
+$(function(){
+  fetchRequests(1);
+
+  $('#statusFilter').on('change', () => fetchRequests(1));
+});
+
+function fetchRequests(page=1){
+  currentPage = page;
+
+  $.ajax({
+    url: `${BASE_URL}/assets/cPhp/get_refund_requests.php`,
+    method: 'GET',
+    dataType: 'json',
+    success(list){
+      renderTable(list);
+      buildPagination();
+      updateUrl(page);
+    },
+    error(xhr, status, err){
+      console.error('Refund fetch failed:', status, err);
+    }
+  });
+}
+
+function renderTable(list){
+  const filter = $('#statusFilter').val();
+  const $tb = $('#refundTable tbody').empty();
+  list.filter(r => !filter || statusOf(r).includes(filter)).forEach(r => {
+    const hist = r.status_history.map(h => `${h.status} (${h.date})`).join('<br>');
+    const proof = r.proof ? `<a href="assets/uploads/${r.proof}" target="_blank">View</a>` : '—';
+    $tb.append(`
+      <tr>
+        <td>#${r.order_id}</td>
+        <td>${r.reason}</td>
+        <td>${proof}</td>
+        <td>${hist}</td>
+      </tr>`);
+  });
+}
+
+function statusOf(r){
+  if(!Array.isArray(r.status_history) || r.status_history.length===0) return '';
+  return r.status_history[r.status_history.length-1].status;
+}
+
+function updateUrl(page){
+  const newUrl = `${window.location.pathname}?page=${page}`;
+  window.history.replaceState({}, '', newUrl);
+}
+
+window.fetchPendingOrders = fetchRequests; // alias for pagination

--- a/assets/js/cJs/sidebar.js
+++ b/assets/js/cJs/sidebar.js
@@ -42,6 +42,7 @@ const sidebarHTML = `
           <li><a href="delivered-orders.php">Delivered Orders</a></li>
           <li><a href="returned-orders.php">Returned Orders</a></li>
           <li><a href="refunded-orders.php">Refunded Orders</a></li>
+          <li><a href="refund-dashboard.php">Refund Dashboard</a></li>
           <li><a href="cancelled-orders.php">Cancelled Orders</a></li>
           <li><a href="orders.php">Orders</a></li>
           <li><a href="shipments.php">shipments</a></li>

--- a/assets/uploads/refund_requests.json
+++ b/assets/uploads/refund_requests.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": 1,
+    "order_id": 2351,
+    "reason": "Item damaged during shipping",
+    "proof": "damage1.png",
+    "status_history": [
+      {"status": "requested", "date": "2024-05-01"},
+      {"status": "approved", "date": "2024-05-02"},
+      {"status": "refunded", "date": "2024-05-03"}
+    ]
+  },
+  {
+    "id": 2,
+    "order_id": 2352,
+    "reason": "Wrong size received",
+    "proof": "size_issue.jpg",
+    "status_history": [
+      {"status": "requested", "date": "2024-06-05"},
+      {"status": "denied", "date": "2024-06-07"}
+    ]
+  }
+]

--- a/refund-dashboard.php
+++ b/refund-dashboard.php
@@ -1,0 +1,74 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/server-config.php';
+$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="shortcut icon" href="assets/images/favicon.svg" type="image/x-icon" />
+  <title>Refund Dashboard</title>
+  <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="assets/css/lineicons.css" />
+  <link rel="stylesheet" href="assets/css/main.css" />
+</head>
+<body>
+  <div id="preloader"><div class="spinner"></div></div>
+  <aside class="sidebar-nav-wrapper">
+    <script src="assets/js/cJs/sidebar.js"></script>
+  </aside>
+  <div class="overlay"></div>
+  <main class="main-wrapper">
+    <header class="header">
+      <script src="assets/js/cJs/header.js"></script>
+      <script src="assets/js/cJs/menuToggle.js"></script>
+    </header>
+    <section class="table-components">
+      <div class="container-fluid">
+        <div class="row pt-30 mb-3 align-items-center">
+          <div class="col"><h2>Refund Dashboard</h2></div>
+          <div class="col-auto">
+            <select id="statusFilter" class="form-select form-select-sm">
+              <option value="">All Statuses</option>
+              <option value="requested">Requested</option>
+              <option value="approved">Approved</option>
+              <option value="denied">Denied</option>
+              <option value="refunded">Refunded</option>
+            </select>
+          </div>
+        </div>
+        <div class="card-style mb-30">
+          <div class="table-responsive">
+            <table class="table" id="refundTable">
+              <thead>
+                <tr>
+                  <th>Order</th>
+                  <th>Reason</th>
+                  <th>Proof</th>
+                  <th>Status History</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+        <nav class="p-3">
+          <ul class="base-pagination pagination"></ul>
+        </nav>
+      </div>
+    </section>
+    <footer class="footer">
+      <script src="assets/js/cJs/footer.js"></script>
+    </footer>
+  </main>
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="assets/js/bootstrap.bundle.min.js"></script>
+  <script src="assets/js/main.js"></script>
+  <script> const BASE_URL = "<?= $BASE_URL ?>"; </script>
+  <script src="assets/js/cJs/refund_requests.js"></script>
+  <script src="assets/js/cJs/pagination.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add endpoint to list refund requests
- add front-end refund dashboard page
- hook dashboard into sidebar
- implement basic renderer and filtering
- sample refund request data

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd8e0a828832fb301f0881647d1da