### PR TITLE
Add payments & billing

### DIFF
--- a/assets/cPhp/download_invoice.php
+++ b/assets/cPhp/download_invoice.php
@@ -1,0 +1,14 @@
+<?php
+// portal/assets/cPhp/download_invoice.php
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$file = __DIR__ . '/../pdf/invoice_sample.pdf';
+if (!file_exists($file)) {
+    http_response_code(404);
+    echo 'File not found';
+    exit;
+}
+header('Content-Type: application/pdf');
+header('Content-Disposition: attachment; filename="invoice-' . $id . '.pdf"');
+readfile($file);
+exit;
+?>

--- a/assets/cPhp/get_invoices.php
+++ b/assets/cPhp/get_invoices.php
@@ -1,0 +1,20 @@
+<?php
+// portal/assets/cPhp/get_invoices.php
+
+header('Content-Type: application/json; charset=utf-8');
+$dataFile = __DIR__ . '/../data/invoices.json';
+if (!file_exists($dataFile)) {
+    echo json_encode([]);
+    exit;
+}
+$invoices = json_decode(file_get_contents($dataFile), true);
+$page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
+$per_page = isset($_GET['per_page']) ? (int)$_GET['per_page'] : 20;
+$total = count($invoices);
+$total_pages = max(1, (int)ceil($total / $per_page));
+header('X-My-TotalPages: ' . $total_pages);
+$start = ($page - 1) * $per_page;
+$items = array_slice($invoices, $start, $per_page);
+echo json_encode($items);
+exit;
+?>

--- a/assets/cPhp/get_payment_terms.php
+++ b/assets/cPhp/get_payment_terms.php
@@ -1,0 +1,12 @@
+<?php
+// portal/assets/cPhp/get_payment_terms.php
+header('Content-Type: application/json; charset=utf-8');
+$file = __DIR__ . '/../data/payment_terms.json';
+if (!file_exists($file)) {
+    echo json_encode([]);
+    exit;
+}
+$data = json_decode(file_get_contents($file), true);
+echo json_encode($data);
+exit;
+?>

--- a/assets/cPhp/update_payment_term.php
+++ b/assets/cPhp/update_payment_term.php
@@ -1,0 +1,32 @@
+<?php
+// portal/assets/cPhp/update_payment_term.php
+$file = __DIR__ . '/../data/payment_terms.json';
+$data = file_exists($file) ? json_decode(file_get_contents($file), true) : [];
+$raw = file_get_contents('php://input');
+$payload = json_decode($raw, true) ?: $_POST;
+$id = isset($payload['id']) ? (int)$payload['id'] : 0;
+$name = isset($payload['name']) ? trim($payload['name']) : '';
+$desc = isset($payload['description']) ? trim($payload['description']) : '';
+if (!$name) {
+    http_response_code(400);
+    echo json_encode(['error'=>'Missing name']);
+    exit;
+}
+if ($id) {
+    foreach ($data as &$t) {
+        if ($t['id'] == $id) {
+            $t['name'] = $name;
+            $t['description'] = $desc;
+            break;
+        }
+    }
+    unset($t);
+} else {
+    $id = count($data) ? max(array_column($data,'id')) + 1 : 1;
+    $data[] = ['id'=>$id,'name'=>$name,'description'=>$desc];
+}
+file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT));
+header('Content-Type: application/json; charset=utf-8');
+echo json_encode(['success'=>true,'id'=>$id]);
+exit;
+?>

--- a/assets/data/invoices.json
+++ b/assets/data/invoices.json
@@ -1,0 +1,12 @@
+[
+  {"id":1,"customer":"Alice","amount":199.99,"status":"Paid","date":"2023-01-15"},
+  {"id":2,"customer":"Bob","amount":299.5,"status":"Unpaid","date":"2023-01-18"},
+  {"id":3,"customer":"Charlie","amount":150.0,"status":"Paid","date":"2023-02-02"},
+  {"id":4,"customer":"Dave","amount":89.95,"status":"Overdue","date":"2023-02-10"},
+  {"id":5,"customer":"Eve","amount":450.25,"status":"Paid","date":"2023-03-01"},
+  {"id":6,"customer":"Frank","amount":120.0,"status":"Unpaid","date":"2023-03-05"},
+  {"id":7,"customer":"Grace","amount":220.75,"status":"Paid","date":"2023-03-15"},
+  {"id":8,"customer":"Heidi","amount":180.0,"status":"Unpaid","date":"2023-04-01"},
+  {"id":9,"customer":"Ivan","amount":99.99,"status":"Paid","date":"2023-04-10"},
+  {"id":10,"customer":"Judy","amount":310.5,"status":"Paid","date":"2023-05-03"}
+]

--- a/assets/data/payment_terms.json
+++ b/assets/data/payment_terms.json
@@ -1,0 +1,5 @@
+[
+  {"id":1,"name":"Net 30","description":"Payment due within 30 days"},
+  {"id":2,"name":"Net 15","description":"Payment due within 15 days"},
+  {"id":3,"name":"Prepaid","description":"Payment required before shipment"}
+]

--- a/assets/js/cJs/invoices.js
+++ b/assets/js/cJs/invoices.js
@@ -1,0 +1,36 @@
+// page-specific fetcher for Invoices
+let currentPage = 1;
+let totalPages  = 1;
+
+$(function(){
+  fetchInvoices(1);
+});
+
+function fetchInvoices(page=1){
+  currentPage = page;
+  $.ajax({
+    url: `${BASE_URL}/assets/cPhp/get_invoices.php`,
+    method: 'GET',
+    data: {page, per_page:20},
+    dataType: 'json',
+    complete(xhr){
+      const tp = parseInt(xhr.getResponseHeader('X-My-TotalPages')) || 1;
+      totalPages = tp;
+      buildPagination();
+    },
+    success(list){
+      let html = '';
+      list.forEach(inv => {
+        html += `<tr>
+          <td>${inv.id}</td>
+          <td>${inv.customer}</td>
+          <td>$${inv.amount}</td>
+          <td>${inv.status}</td>
+          <td>${inv.date}</td>
+          <td><a href="${BASE_URL}/assets/cPhp/download_invoice.php?id=${inv.id}" class="btn btn-sm btn-primary">PDF</a></td>
+        </tr>`;
+      });
+      $('#invoiceTable tbody').html(html);
+    }
+  });
+}

--- a/assets/js/cJs/payment_terms.js
+++ b/assets/js/cJs/payment_terms.js
@@ -1,0 +1,50 @@
+// JS for Payment Terms management
+$(function(){
+  loadTerms();
+  $('#addTerm').on('click', function(){
+    $('#termId').val('');
+    $('#termName').val('');
+    $('#termDesc').val('');
+    $('#termModal').modal('show');
+  });
+  $('#saveTerm').on('click', saveTerm);
+});
+
+function loadTerms(){
+  $.getJSON(`${BASE_URL}/assets/cPhp/get_payment_terms.php`, function(data){
+    let html='';
+    data.forEach(t=>{
+      html += `<tr data-id="${t.id}">
+        <td>${t.name}</td>
+        <td>${t.description}</td>
+        <td><button class="btn btn-sm btn-secondary edit-term">Edit</button></td>
+      </tr>`;
+    });
+    $('#termsTable tbody').html(html);
+    $('.edit-term').on('click', function(){
+      const tr=$(this).closest('tr');
+      $('#termId').val(tr.data('id'));
+      $('#termName').val(tr.find('td:nth-child(1)').text());
+      $('#termDesc').val(tr.find('td:nth-child(2)').text());
+      $('#termModal').modal('show');
+    });
+  });
+}
+
+function saveTerm(){
+  const payload={
+    id: $('#termId').val(),
+    name: $('#termName').val(),
+    description: $('#termDesc').val()
+  };
+  $.ajax({
+    url:`${BASE_URL}/assets/cPhp/update_payment_term.php`,
+    method:'POST',
+    contentType:'application/json',
+    data: JSON.stringify(payload),
+    success: function(){
+      $('#termModal').modal('hide');
+      loadTerms();
+    }
+  });
+}

--- a/assets/js/cJs/sidebar.js
+++ b/assets/js/cJs/sidebar.js
@@ -50,6 +50,22 @@ const sidebarHTML = `
         </ul>
       </li>
       <span class="divider"><hr /></span>
+      <!-- Payments & Billing -->
+      <li class="nav-item nav-item-has-children">
+        <a href="#0" class="collapsed" data-bs-toggle="collapse" data-bs-target="#ddmenu_pay" aria-controls="ddmenu_pay" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="icon">
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M2 4.16667C2 3.24619 2.74619 2.5 3.66667 2.5H16.3333C17.2538 2.5 18 3.24619 18 4.16667V15.8333C18 16.7538 17.2538 17.5 16.3333 17.5H3.66667C2.74619 17.5 2 16.7538 2 15.8333V4.16667Z" />
+              <path d="M2 6.66667H18" />
+            </svg>
+          </span>
+          <span class="text">Payments & Billing</span>
+        </a>
+        <ul id="ddmenu_pay" class="collapse dropdown-nav">
+          <li><a href="invoices.php">Invoices</a></li>
+          <li><a href="payment-terms.php">Payment Terms</a></li>
+        </ul>
+      </li>
       <!-- Additional sidebar sections can be added here -->
     </ul>
   </nav>

--- a/assets/pdf/invoice_sample.pdf
+++ b/assets/pdf/invoice_sample.pdf
@@ -1,0 +1,7 @@
+%PDF-1.4
+1 0 obj
+<<>>
+endobj
+trailer
+<<>>
+%%EOF

--- a/invoices.php
+++ b/invoices.php
@@ -1,0 +1,69 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/server-config.php';
+$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="shortcut icon" href="assets/images/favicon.svg" type="image/x-icon" />
+  <title>Tharavix | Invoices</title>
+  <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="assets/css/lineicons.css" />
+  <link rel="stylesheet" href="assets/css/materialdesignicons.min.css" />
+  <link rel="stylesheet" href="assets/css/main.css" />
+  <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+</head>
+<body>
+  <div id="preloader"><div class="spinner"></div></div>
+  <aside class="sidebar-nav-wrapper">
+    <script src="assets/js/cJs/sidebar.js"></script>
+  </aside>
+  <div class="overlay"></div>
+  <main class="main-wrapper">
+    <header class="header">
+      <script src="assets/js/cJs/header.js"></script>
+      <script src="assets/js/cJs/menuToggle.js"></script>
+    </header>
+    <section class="table-components">
+      <div class="container-fluid">
+        <div class="title-wrapper pt-30 mb-3">
+          <div class="row align-items-center">
+            <div class="col-md-6"><h2>Invoices</h2></div>
+          </div>
+        </div>
+        <div class="card-style mb-30">
+          <div class="table-responsive">
+            <table class="table" id="invoiceTable">
+              <thead class="table-light">
+                <tr>
+                  <th>ID</th>
+                  <th>Customer</th>
+                  <th>Amount</th>
+                  <th>Status</th>
+                  <th>Date</th>
+                  <th>Download</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <nav class="p-3">
+            <ul class="base-pagination pagination"></ul>
+          </nav>
+        </div>
+      </div>
+    </section>
+    <footer class="footer">
+      <script src="assets/js/cJs/footer.js"></script>
+    </footer>
+  </main>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="assets/js/bootstrap.bundle.min.js"></script>
+  <script src="assets/js/main.js"></script>
+  <script src="assets/js/cJs/invoices.js"></script>
+  <script src="assets/js/cJs/pagination.js"></script>
+</body>
+</html>

--- a/payment-terms.php
+++ b/payment-terms.php
@@ -1,0 +1,84 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/server-config.php';
+$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="shortcut icon" href="assets/images/favicon.svg" type="image/x-icon" />
+  <title>Tharavix | Payment Terms</title>
+  <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="assets/css/lineicons.css" />
+  <link rel="stylesheet" href="assets/css/materialdesignicons.min.css" />
+  <link rel="stylesheet" href="assets/css/main.css" />
+  <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+</head>
+<body>
+  <div id="preloader"><div class="spinner"></div></div>
+  <aside class="sidebar-nav-wrapper">
+    <script src="assets/js/cJs/sidebar.js"></script>
+  </aside>
+  <div class="overlay"></div>
+  <main class="main-wrapper">
+    <header class="header">
+      <script src="assets/js/cJs/header.js"></script>
+      <script src="assets/js/cJs/menuToggle.js"></script>
+    </header>
+    <section class="table-components">
+      <div class="container-fluid">
+        <div class="title-wrapper pt-30 mb-3 d-flex justify-content-between align-items-center">
+          <h2>Payment Terms</h2>
+          <button id="addTerm" class="main-btn primary-btn btn-hover btn-sm">Add Term</button>
+        </div>
+        <div class="card-style mb-30">
+          <div class="table-responsive">
+            <table class="table" id="termsTable">
+              <thead class="table-light">
+                <tr><th>Name</th><th>Description</th><th>Actions</th></tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+    <footer class="footer">
+      <script src="assets/js/cJs/footer.js"></script>
+    </footer>
+  </main>
+
+  <!-- Modal -->
+  <div class="modal fade" id="termModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Payment Term</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <input type="hidden" id="termId" />
+          <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input type="text" class="form-control" id="termName" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Description</label>
+            <textarea class="form-control" id="termDesc"></textarea>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" id="saveTerm">Save</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="assets/js/bootstrap.bundle.min.js"></script>
+  <script src="assets/js/main.js"></script>
+  <script src="assets/js/cJs/payment_terms.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add invoice listing and payment term management pages
- create APIs for invoices and payment terms
- wire up JS for invoices and payment terms
- include placeholder invoice PDF download
- extend sidebar with Payments & Billing navigation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd8e0b640832fb11856c103600f06