### PR TITLE
Fix pagination test context execution

### DIFF
--- a/tests/pagination.test.js
+++ b/tests/pagination.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
+const { JSDOM } = require('jsdom');
 const jquery = require('jquery');
 
 let script;
@@ -10,14 +11,18 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  // Jest uses jsdom environment by default
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
   global.$ = jquery(global.window);
   document.body.innerHTML = '<ul class="base-pagination pagination"></ul>';
-  vm.runInThisContext(script);
+  vm.runInNewContext(script, global);
 });
 
 afterEach(() => {
   delete global.$;
+  delete global.window;
+  delete global.document;
   delete global.buildPagination;
   delete global.currentPage;
   delete global.totalPages;


### PR DESCRIPTION
## Summary
- run pagination.js script in a VM context with the global object
- initialize jsdom and jQuery per test so the pagination builder runs correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fe42d00e8832f9284f6ff6da3b9ab