### PR TITLE
Specify Node requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ STORE_URL=https://example.com
 
 ## Running Tests
 
-Install dependencies and run the test suite:
+Install dependencies and run the test suite. Requires Node.js >=18:
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "repository": "https://github.com/PlainAdmin/plainadmin.git",
   "author": "plainadmin team",
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "devDependencies": {
     "browser-sync": "^3.0.4",
     "gulp": "^5.0.1",


### PR DESCRIPTION
## Summary
- specify Node.js v18 requirement in package.json
- document Node.js v18 in README

## Testing
- `npm test` *(fails: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_683fe9653300832fb1ebfc662fbdb936