### PR TITLE
Allow server base URL override from env

### DIFF
--- a/assets/cPhp/server-config.php
+++ b/assets/cPhp/server-config.php
@@ -2,9 +2,16 @@
 $environment = 'local'; // 'local' or 'live'
 
 $config = [
-  'local' => ['base_url' => 'http://localhost/portal'],
-  'live'  => ['base_url' => 'https://portal.tootfunyachts.com'],
+    'local' => ['base_url' => 'http://localhost/portal'],
+    'live'  => ['base_url' => 'https://portal.tootfunyachts.com'],
 ];
 
-define('PROJECT_BASE_URL', $config[$environment]['base_url']);
+// Allow overriding the base URL using an environment variable
+$envBaseUrl = getenv('PROJECT_BASE_URL');
+
+$baseUrl = ($envBaseUrl !== false && $envBaseUrl !== '')
+    ? $envBaseUrl
+    : $config[$environment]['base_url'];
+
+define('PROJECT_BASE_URL', $baseUrl);
 ?>


### PR DESCRIPTION
## Summary
- allow overriding the portal base URL with the PROJECT_BASE_URL environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fee54f8cc832fb538ee4c2f8a97a7