### PR TITLE
Add tests for orders.js

### DIFF
--- a/assets/js/cJs/orders.js
+++ b/assets/js/cJs/orders.js
@@ -127,3 +127,8 @@ $(function(){
   });
   fetchOrders(1);
 });
+
+// export for testing
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { renderOrders };
+}

--- a/tests/orders.test.js
+++ b/tests/orders.test.js
@@ -1,0 +1,43 @@
+describe('orders.js renderOrders', () => {
+  let renderOrders;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<table><tbody id="orders-body"></tbody></table>';
+    delete require.cache[require.resolve('jquery')];
+    global.$ = require('jquery');
+    global.$.ajax = jest.fn(opts => {
+      if (opts.success) opts.success([]);
+      if (opts.complete) opts.complete({ getResponseHeader: () => '1' });
+    });
+    delete require.cache[require.resolve('../assets/js/cJs/orders.js')];
+    const mod = require('../assets/js/cJs/orders.js');
+    renderOrders = mod.renderOrders;
+  });
+
+  afterEach(() => {
+    delete global.$;
+  });
+
+  test('shows message when no orders', () => {
+    renderOrders([]);
+    const text = document.querySelector('#orders-body').textContent;
+    expect(text).toContain('No orders to display');
+  });
+
+  test('adds a row for each order', () => {
+    const orders = [{
+      id: 1,
+      date_created: '2024-01-01T00:00:00Z',
+      billing: { first_name: 'John', last_name: 'Doe' },
+      total: '12.34',
+      status: 'new',
+      meta_data: []
+    }];
+    renderOrders(orders);
+    const rows = document.querySelectorAll('#orders-body tr');
+    expect(rows.length).toBe(1);
+    const rowText = rows[0].textContent;
+    expect(rowText).toContain('#1');
+    expect(rowText).toContain('AED 12.34');
+  });
+});


### PR DESCRIPTION
## Summary
- export `renderOrders` for testing
- add Jest tests for `renderOrders`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fee5a7a28832f86d1cea7b49827d5