### PR TITLE
Guard error display in shipments summary

### DIFF
--- a/assets/cPhp/get_shipments_summary.php
+++ b/assets/cPhp/get_shipments_summary.php
@@ -1,7 +1,9 @@
 <?php
-// Enable errors for debugging
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
+// Enable detailed errors only when DEBUG environment variable is truthy
+if (getenv('DEBUG')) {
+    ini_set('display_errors', '1');
+    error_reporting(E_ALL);
+}
 
 require_once __DIR__ . '/master-api.php';  // loads $store_url, $consumer_key, $consumer_secret
 


### PR DESCRIPTION
## Summary
- only enable verbose PHP errors in get_shipments_summary.php when `DEBUG` env var is set

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683ff66a9d38832f8aee187ca6ff9b21