### PR TITLE
Fix delivered orders loading

### DIFF
--- a/assets/js/cJs/orders.js
+++ b/assets/js/cJs/orders.js
@@ -6,7 +6,7 @@ const endpointMap = {
   pending:      'get_pending_orders.php',
   processing:   'get_processing_orders.php',
   'in-transit': 'get_in_transit_orders.php',
-  completed:    'get_completed_orders.php',
+  completed:    'get_delivered_orders.php',
   returned:     'get_returned_orders.php',
   refunded:     'get_refunded_orders.php',
   cancelled:    'get_cancelled_orders.php'

--- a/assets/js/cJs/refunded_orders.js
+++ b/assets/js/cJs/refunded_orders.js
@@ -14,7 +14,7 @@ function fetchDeliveredOrders(page) {
   currentPage = page;
 
   $.ajax({
-    url: `${BASE_URL}/assets/cPhp/get_completed_orders.php`,
+    url: `${BASE_URL}/assets/cPhp/get_delivered_orders.php`,
     method: 'GET',
     data: { page, per_page: PER_PAGE },
     dataType: 'json',


### PR DESCRIPTION
## Summary
- use `get_delivered_orders.php` endpoint when listing delivered orders
- update refunded orders script to hit new endpoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683ff6691fe4832fb5f5936ce2763b01