### PR TITLE
Add dedicated single shipment update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,13 @@ Install dependencies and run the test suite. Requires Node.js >=18:
 npm install
 npm test
 ```
+
+## Shipment Update Endpoints
+
+Two PHP scripts handle shipment updates:
+
+- `assets/cPhp/upload_manifest.php` – Upload a CSV manifest under the form field
+  `manifest` to bulk update orders with tracking numbers, providers and ETAs.
+- `assets/cPhp/update_single_shipment.php` – Accepts a JSON body containing an
+  `order_id` plus optional `provider`, `tracking_no` and `eta` values. It updates
+  a single WooCommerce order and is used when editing rows in `shipments.js`.

--- a/assets/cPhp/update_single_shipment.php
+++ b/assets/cPhp/update_single_shipment.php
@@ -1,0 +1,52 @@
+<?php
+// assets/cPhp/update_single_shipment.php
+// Update tracking information for a single order via JSON payload
+
+require_once __DIR__ . '/master-api.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$raw  = file_get_contents('php://input');
+$data = json_decode($raw, true) ?: $_POST;
+
+$order_id = isset($data['order_id']) ? (int)$data['order_id'] : 0;
+if (!$order_id) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing order_id']);
+    exit;
+}
+
+$meta = [];
+if (isset($data['provider'])) {
+    $meta[] = ['key' => '_wot_tracking_carrier', 'value' => $data['provider']];
+}
+if (isset($data['tracking_no'])) {
+    $meta[] = ['key' => '_wot_tracking_number', 'value' => $data['tracking_no']];
+}
+if (isset($data['eta'])) {
+    $meta[] = ['key' => '_wot_eta', 'value' => $data['eta']];
+}
+
+if (empty($meta)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'No fields to update']);
+    exit;
+}
+
+$payload = ['meta_data' => $meta];
+$ch = curl_init(rtrim($store_url, '/') . "/wp-json/wc/v3/orders/{$order_id}");
+curl_setopt_array($ch, [
+    CURLOPT_CUSTOMREQUEST  => 'PUT',
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_USERPWD        => "$consumer_key:$consumer_secret",
+    CURLOPT_HTTPHEADER     => ['Content-Type: application/json'],
+    CURLOPT_POSTFIELDS     => json_encode($payload)
+]);
+$response = curl_exec($ch);
+$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+http_response_code($code);
+echo $response !== false ? $response : json_encode(['error' => 'Request failed']);
+exit;
+?>

--- a/assets/js/cJs/shipments.js
+++ b/assets/js/cJs/shipments.js
@@ -49,7 +49,7 @@ $(function(){
     const eta      = $row.find('.eta-input').val()?.trim() || '';
 
     $.ajax({
-      url: `${BASE_URL}/assets/cPhp/update_shipment.php`,
+      url: `${BASE_URL}/assets/cPhp/update_single_shipment.php`,
       method: 'POST',
       contentType: 'application/json',
       data: JSON.stringify({


### PR DESCRIPTION
## Summary
- introduce `update_single_shipment.php` for JSON updates of an order's tracking data
- route row edits in `shipments.js` to the new endpoint
- document both shipment update PHP scripts in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840141a7b28832f84ced193297e717b