### PR TITLE
Fix refunded orders fetcher

### DIFF
--- a/assets/js/cJs/refunded_orders.js
+++ b/assets/js/cJs/refunded_orders.js
@@ -1,4 +1,4 @@
-// assets/js/cJs/delivered_orders.js
+// assets/js/cJs/refunded_orders.js
 
 let currentPage = 1;
 let totalPages  = 1;
@@ -7,14 +7,14 @@ const PER_PAGE  = 20;
 $(document).ready(function() {
   const params   = new URLSearchParams(window.location.search);
   const pageParm = parseInt(params.get('page'), 10) || 1;
-  fetchDeliveredOrders(pageParm);
+  fetchRefundedOrders(pageParm);
 });
 
-function fetchDeliveredOrders(page) {
+function fetchRefundedOrders(page) {
   currentPage = page;
 
   $.ajax({
-    url: `${BASE_URL}/assets/cPhp/get_delivered_orders.php`,
+    url: `${BASE_URL}/assets/cPhp/get_refunded_orders.php`,
     method: 'GET',
     data: { page, per_page: PER_PAGE },
     dataType: 'json',
@@ -25,8 +25,8 @@ function fetchDeliveredOrders(page) {
       updateUrl(page);
     },
     error(xhr, status, err) {
-      console.error('Error fetching delivered orders:', status, err);
-      alert('❌ Could not load delivered orders');
+      console.error('Error fetching refunded orders:', status, err);
+      alert('❌ Could not load refunded orders');
     }
   });
 }


### PR DESCRIPTION
## Summary
- update refunded_orders.js to call and define `fetchRefundedOrders`
- point AJAX call at `get_refunded_orders.php`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401417d7b0832fb1753b21d59b206e