### PR TITLE
Handle JSON payloads in shipment updates

### DIFF
--- a/assets/cPhp/update_shipment.php
+++ b/assets/cPhp/update_shipment.php
@@ -2,44 +2,96 @@
 // portal/assets/cPhp/update_shipment.php
 require_once __DIR__ . '/master-api.php';
 
-if (empty($_FILES['manifest']) || $_FILES['manifest']['error']) {
-  http_response_code(400);
-  echo json_encode(['error'=>'No file']);
-  exit;
+header('Content-Type: application/json; charset=utf-8');
+
+$ctype = $_SERVER['CONTENT_TYPE'] ?? '';
+
+// ---------------------------------------------------------------------
+// JSON request - inline update from shipments.js
+// ---------------------------------------------------------------------
+if (stripos($ctype, 'application/json') !== false) {
+    $raw  = file_get_contents('php://input');
+    $data = json_decode($raw, true);
+
+    if (!is_array($data)) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid JSON payload']);
+        exit;
+    }
+
+    $orderId  = isset($data['order_id']) ? (int)$data['order_id'] : 0;
+    $provider = trim($data['provider'] ?? '');
+    $tracking = trim($data['tracking_no'] ?? '');
+    $eta      = trim($data['eta'] ?? '');
+
+    if (!$orderId) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing order_id']);
+        exit;
+    }
+
+    $meta = [];
+    if ($tracking !== '')  $meta[] = ['key' => '_wot_tracking_number',  'value' => $tracking];
+    if ($provider !== '')  $meta[] = ['key' => '_wot_tracking_carrier', 'value' => $provider];
+    if ($eta !== '')       $meta[] = ['key' => '_wot_eta',              'value' => $eta];
+
+    $payload = ['meta_data' => $meta];
+
+    $ch = curl_init(rtrim($store_url, '/') . "/wp-json/wc/v3/orders/{$orderId}");
+    curl_setopt_array($ch, [
+        CURLOPT_CUSTOMREQUEST  => 'PUT',
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_USERPWD        => "$consumer_key:$consumer_secret",
+        CURLOPT_HTTPHEADER     => ['Content-Type: application/json'],
+        CURLOPT_POSTFIELDS     => json_encode($payload)
+    ]);
+    curl_exec($ch);
+    curl_close($ch);
+
+    echo json_encode(['success' => true]);
+    exit;
 }
 
-$tmp = fopen($_FILES['manifest']['tmp_name'],'r');
+// ---------------------------------------------------------------------
+// CSV upload - manifest file
+// ---------------------------------------------------------------------
+if (empty($_FILES['manifest']) || $_FILES['manifest']['error']) {
+    http_response_code(400);
+    echo json_encode(['error' => 'No file']);
+    exit;
+}
+
+$tmp = fopen($_FILES['manifest']['tmp_name'], 'r');
 if (!$tmp) {
-  http_response_code(500);
-  echo json_encode(['error'=>'Upload failed']);
-  exit;
+    http_response_code(500);
+    echo json_encode(['error' => 'Upload failed']);
+    exit;
 }
 
 // Skip header if present
 $first = fgetcsv($tmp);
 
 while (($row = fgetcsv($tmp)) !== false) {
-  list($order_id,$provider,$tracking,$eta) = $row;
+    list($order_id, $provider, $tracking, $eta) = $row;
 
-  $payload = ['meta_data'=>[
-    ['key'=>'_wot_tracking_number','value'=>$tracking],
-    ['key'=>'_wot_tracking_carrier','value'=>$provider],
-    ['key'=>'_wot_eta','value'=>$eta]
-  ]];
+    $payload = ['meta_data' => [
+        ['key' => '_wot_tracking_number',  'value' => $tracking],
+        ['key' => '_wot_tracking_carrier', 'value' => $provider],
+        ['key' => '_wot_eta',              'value' => $eta]
+    ]];
 
-  // PUT to Woo
-  $ch = curl_init(rtrim($store_url,'/') . "/wp-json/wc/v3/orders/{$order_id}");
-  curl_setopt_array($ch,[
-    CURLOPT_CUSTOMREQUEST  => 'PUT',
-    CURLOPT_RETURNTRANSFER => true,
-    CURLOPT_USERPWD        => "$consumer_key:$consumer_secret",
-    CURLOPT_HTTPHEADER     => ['Content-Type: application/json'],
-    CURLOPT_POSTFIELDS     => json_encode($payload)
-  ]);
-  curl_exec($ch);
-  curl_close($ch);
+    $ch = curl_init(rtrim($store_url, '/') . "/wp-json/wc/v3/orders/{$order_id}");
+    curl_setopt_array($ch, [
+        CURLOPT_CUSTOMREQUEST  => 'PUT',
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_USERPWD        => "$consumer_key:$consumer_secret",
+        CURLOPT_HTTPHEADER     => ['Content-Type: application/json'],
+        CURLOPT_POSTFIELDS     => json_encode($payload)
+    ]);
+    curl_exec($ch);
+    curl_close($ch);
 }
 
-echo json_encode(['success'=>true]);
+echo json_encode(['success' => true]);
 exit;
 ?>


### PR DESCRIPTION
## Summary
- detect `application/json` requests in `update_shipment.php`
- update a single WooCommerce order when JSON is posted
- keep CSV manifest processing as fallback

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684014174390832f97f5d4c5ec4921c4