### PR TITLE
Add logistics orders script and update page

### DIFF
--- a/assets/js/cJs/logistics_orders.js
+++ b/assets/js/cJs/logistics_orders.js
@@ -1,0 +1,59 @@
+// assets/js/cJs/logistics_orders.js
+// Fetch logistics/shipment orders summary and populate table with pagination
+
+let currentPage = 1;
+let totalPages  = 1;
+const PER_PAGE  = 20;
+
+$(function(){
+  const p = parseInt(new URLSearchParams(location.search).get('page'), 10) || 1;
+  fetchLogisticsOrders(p);
+});
+
+function fetchLogisticsOrders(page=1){
+  currentPage = page;
+  $.ajax({
+    url: 'assets/cPhp/get_shipments_summary.php',
+    method: 'GET',
+    data: { page, per_page: PER_PAGE },
+    dataType: 'json',
+    success(list, textStatus, xhr){
+      const $tb = $('table tbody').empty();
+      list.forEach(o => {
+        $tb.append(`
+          <tr>
+            <td>#${o.order_id}</td>
+            <td>${formatDate(o.last_update)}</td>
+            <td>${o.status}</td>
+            <td>-</td>
+            <td>-</td>
+            <td><button class="btn btn-sm btn-primary view-btn" data-id="${o.order_id}"><i class="lni lni-eye"></i></button></td>
+            <td>${o.tracking_no || ''}</td>
+            <td>${o.provider || ''}</td>
+          </tr>
+        `);
+      });
+
+      totalPages = parseInt(xhr.getResponseHeader('X-My-TotalPages'), 10) || 1;
+      buildPagination();
+      updateUrl(page);
+    },
+    error(xhr, status, err){
+      console.error('Failed to fetch logistics orders:', err);
+      alert('Failed to load logistics orders');
+    }
+  });
+}
+
+// expose for pagination.js
+window.fetchPendingOrders = fetchLogisticsOrders;
+
+function updateUrl(page){
+  const newUrl = `${window.location.pathname}?page=${page}`;
+  window.history.replaceState({}, '', newUrl);
+}
+
+function formatDate(str){
+  if(!str) return '';
+  return new Date(str).toLocaleDateString('en-US',{month:'short',day:'numeric',year:'numeric'});
+}

--- a/logistics-orders.html
+++ b/logistics-orders.html
@@ -86,7 +86,7 @@
                         </tr>
                       </thead>
                       <tbody>
-                        <!-- Dynamically injected rows from cancelled_orders.js -->
+                        <!-- Dynamically injected rows from logistics_orders.js -->
                       </tbody>
                     </table>
                   </div>
@@ -94,6 +94,10 @@
                 <!-- end card -->
               </div>
             </div>
+            <!-- Pagination -->
+            <nav>
+              <ul class="base-pagination pagination"></ul>
+            </nav>
           </div>
         </div>
       </section>
@@ -118,7 +122,8 @@
     <script src="assets/js/polyfill.js"></script>
     <script src="assets/js/main.js"></script>
 
-    <!-- Your updated JS that fetches cancelled orders and matches WooCommerce style -->
-    <script src="assets/js/cJs/cancelled_orders.js"></script>
+    <!-- JS to load logistics orders and pagination -->
+    <script src="assets/js/cJs/logistics_orders.js"></script>
+    <script src="assets/js/cJs/pagination.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add new `logistics_orders.js` to fetch shipment data
- update `logistics-orders.html` to use new script and include pagination

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401418a94c832fb34273c491039038