### PR TITLE
Update README for env variable error

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,15 @@ If you are looking for a high-quality free admin template that comes with all es
 
 ## Environment Configuration
 
-The PHP scripts under `assets/cPhp` expect the following environment variables to be present:
+The PHP scripts under `assets/cPhp` expect the following environment variables to be present.
+`master-api.php` will terminate early if any of the first three variables are missing:
 
 - `WOOCOMMERCE_CK` – WooCommerce consumer key
 - `WOOCOMMERCE_CS` – WooCommerce consumer secret
 - `STORE_URL` – URL of your WooCommerce store
 - `TRACK17_APIKEY` – API key for communicating with [17TRACK](https://www.17track.net/)
 
-Create a `.env` file in the project root containing these variables and export them in your server environment before running the application:
+Create a `.env` file in the project root containing these variables and export them in your server environment before running the application. If `WOOCOMMERCE_CK`, `WOOCOMMERCE_CS`, or `STORE_URL` are unset you will see the error message `Environment variables WOOCOMMERCE_CK, WOOCOMMERCE_CS and STORE_URL must be set.` when a PHP page loads:
 
 ```bash
 WOOCOMMERCE_CK=your_key
@@ -90,6 +91,23 @@ WOOCOMMERCE_CS=your_secret
 STORE_URL=https://example.com
 TRACK17_APIKEY=your_api_key
 ```
+
+## Troubleshooting
+
+If a PHP script exits with the message:
+
+```
+Environment variables WOOCOMMERCE_CK, WOOCOMMERCE_CS and STORE_URL must be set.
+```
+
+the application could not locate your WooCommerce credentials. Copy `.env.example` to `.env` and fill in your keys:
+
+```bash
+cp .env.example .env
+# then edit .env
+```
+
+Reload your server after exporting the variables so `master-api.php` can read them.
 
 ## PHP Version & Local Server
 


### PR DESCRIPTION
## Summary
- mention that `master-api.php` stops if WooCommerce variables aren't set
- document how to copy `.env.example` and fix the error

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684028b73ed4832fb69d57c9d9c42d53