### PR TITLE
Escape HTML when rendering API data

### DIFF
--- a/assets/js/cJs/delivered_orders.js
+++ b/assets/js/cJs/delivered_orders.js
@@ -4,6 +4,14 @@ let currentPage = 1;
 let totalPages  = 1;
 const PER_PAGE  = 20;
 
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 $(function() {
   // grab ?page=... from URL if present
   const params = new URLSearchParams(location.search);
@@ -47,28 +55,28 @@ function renderTable(orders) {
     // billing might be missing on some older/custom statuses
     const first = o.billing?.first_name  || '';
     const last  = o.billing?.last_name   || '';
-    const email = o.billing?.email       || 'No Email';
-    const name  = (first + ' ' + last).trim() || 'No Name';
+    const email = escapeHtml(o.billing?.email       || 'No Email');
+    const name  = escapeHtml((first + ' ' + last).trim() || 'No Name');
     const date  = o.date_created
-      ? new Date(o.date_created).toLocaleDateString('en-US', { month:'short', day:'numeric', year:'numeric' })
+      ? escapeHtml(new Date(o.date_created).toLocaleDateString('en-US', { month:'short', day:'numeric', year:'numeric' }))
       : 'No Date';
 
     // items
     const items = (o.line_items || []).length
-       ? o.line_items.map(i => `<p>${i.quantity}× ${i.name}</p>`).join('')
+       ? o.line_items.map(i => `<p>${escapeHtml(i.quantity)}× ${escapeHtml(i.name)}</p>`).join('')
        : '<p>No Items</p>';
 
     // status badge
     const st = o.status;
-    const badge = `<mark class="order-status status-${st}"><span>${st.replace('-', ' ')}</span></mark>`;
+    const badge = `<mark class="order-status status-${escapeHtml(st)}"><span>${escapeHtml(st.replace('-', ' '))}</span></mark>`;
 
     // any existing tracking in meta_data?
     const meta = o.meta_data || [];
-    const trk  = meta.find(m => /tracking/i.test(m.key))?.value || '';
+    const trk  = escapeHtml(meta.find(m => /tracking/i.test(m.key))?.value || '');
 
     $tb.append(`
-      <tr data-order-id="${o.id}">
-        <td>#${o.id}<br/><small>${name}</small></td>
+      <tr data-order-id="${escapeHtml(o.id)}">
+        <td>#${escapeHtml(o.id)}<br/><small>${name}</small></td>
         <td><a href="mailto:${email}">${email}</a></td>
         <td>${date}</td>
         <td class="items-col">${items}</td>

--- a/assets/js/cJs/inventory-management.js
+++ b/assets/js/cJs/inventory-management.js
@@ -4,6 +4,14 @@ let currentPage = 1;
 let totalPages  = 1;
 let allItems    = [];
 
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 $(function() {
   // 1) On load, read ?page= or default to 1
   const params = new URLSearchParams(window.location.search);
@@ -71,12 +79,12 @@ function renderTable() {
   filtered.forEach(i => {
     $tb.append(`
       <tr>
-        <td>${i.id}</td>
-        <td>${i.name}</td>
-        <td>${i.stock_quantity ?? 'N/A'}</td>
+        <td>${escapeHtml(i.id)}</td>
+        <td>${escapeHtml(i.name)}</td>
+        <td>${escapeHtml(i.stock_quantity ?? 'N/A')}</td>
         <td>
           <span class="badge ${i.stock_status === 'instock' ? 'bg-success' : 'bg-danger'}">
-            ${i.stock_status}
+            ${escapeHtml(i.stock_status)}
           </span>
         </td>
       </tr>

--- a/assets/js/cJs/new_orders.js
+++ b/assets/js/cJs/new_orders.js
@@ -2,6 +2,14 @@
 let currentPage = 1;
 let totalPages  = 1;
 
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 $(function(){
   fetchNewOrders(1);
 });
@@ -26,25 +34,25 @@ function fetchNewOrders(page = 1) {
     success(orders) {
       let html = '';
       orders.forEach(o => {
-        const idText = o.id ? `#${o.id}` : '#N/A';
-        const name = ((o.billing?.first_name || '') + ' ' + (o.billing?.last_name || '')).trim() || 'No Name';
-        const email = o.billing?.email || 'No Email';
+        const idText = o.id ? `#${escapeHtml(o.id)}` : '#N/A';
+        const name = escapeHtml(((o.billing?.first_name || '') + ' ' + (o.billing?.last_name || '')).trim() || 'No Name');
+        const email = escapeHtml(o.billing?.email || 'No Email');
 
         let date = 'No Date';
         if (o.date_created) {
-          date = new Date(o.date_created)
-                   .toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+          date = escapeHtml(new Date(o.date_created)
+                   .toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }));
         }
 
         let itemsHtml = '<p>No Items</p>';
         if (Array.isArray(o.line_items) && o.line_items.length) {
-          itemsHtml = o.line_items.map(i => `<p>${i.name} – Qty ${i.quantity}</p>`).join('');
+          itemsHtml = o.line_items.map(i => `<p>${escapeHtml(i.name)} – Qty ${escapeHtml(i.quantity)}</p>`).join('');
         }
 
         const statusDd = `
           <div class="btn-group">
             <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown">
-              <span class="status-text">${o.status}</span>
+              <span class="status-text">${escapeHtml(o.status)}</span>
             </button>
             <ul class="dropdown-menu">
               <li><a class="dropdown-item" href="#" data-status="pending">Pending</a></li>
@@ -73,7 +81,7 @@ function fetchNewOrders(page = 1) {
         }
 
         html += `
-          <tr data-order-id="${o.id}">
+          <tr data-order-id="${escapeHtml(o.id)}">
             <td><p>${idText} ${name}</p></td>
             <td><p><a href="mailto:${email}">${email}</a></p></td>
             <td><p>${date}</p></td>
@@ -81,7 +89,7 @@ function fetchNewOrders(page = 1) {
             <td>${statusDd}</td>
             <td>
               <form class="tracking-form d-flex align-items-center">
-                <input type="text" class="form-control tracking-code-input" placeholder="Tracking Code" value="${tracking}">
+                <input type="text" class="form-control tracking-code-input" placeholder="Tracking Code" value="${escapeHtml(tracking)}">
                 <button type="submit" class="btn btn-link p-0 ms-2 update-btn" title="Update">
                   <i class="lni lni-checkmark-circle" style="font-size:1.5rem;color:#28a745"></i>
                 </button>

--- a/assets/js/cJs/orders.js
+++ b/assets/js/cJs/orders.js
@@ -16,6 +16,14 @@ let currentStatus = 'new';
 let currentPage   = 1;
 let totalPages    = 1;
 
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 // fetch + render
 function fetchOrders(page = 1) {
   currentPage = page;
@@ -51,16 +59,16 @@ function renderOrders(orders) {
     const exist = meta ? meta.value : '';
     $body.append(`
       <tr>
-        <td>#${o.id}</td>
-        <td>${date}</td>
-        <td>${(o.billing?.first_name||'') + ' ' + (o.billing?.last_name||'')}</td>
-        <td>AED ${parseFloat(o.total).toFixed(2)}</td>
-        <td>${o.status.replace('-', ' ')}</td>
+        <td>#${escapeHtml(o.id)}</td>
+        <td>${escapeHtml(date)}</td>
+        <td>${escapeHtml((o.billing?.first_name||'') + ' ' + (o.billing?.last_name||''))}</td>
+        <td>AED ${escapeHtml(parseFloat(o.total).toFixed(2))}</td>
+        <td>${escapeHtml(o.status.replace('-', ' '))}</td>
         <td>
           <button class="btn btn-sm btn-success me-1"
-                  onclick="openTracking(${o.id}, '${exist}')">Track</button>
+                  onclick="openTracking(${escapeHtml(o.id)}, '${escapeHtml(exist)}')">Track</button>
           <button class="btn btn-sm btn-secondary"
-                  onclick="openComment(${o.id})">Comment</button>
+                  onclick="openComment(${escapeHtml(o.id)})">Comment</button>
         </td>
       </tr>
     `);

--- a/assets/js/cJs/pending_orders.js
+++ b/assets/js/cJs/pending_orders.js
@@ -4,6 +4,14 @@ let currentPage = 1;
 let totalPages  = 1;
 const PER_PAGE = 20;
 
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 $(document).ready(function() {
   // Read ?page= from URL if present
   const params   = new URLSearchParams(window.location.search);
@@ -42,17 +50,17 @@ function renderTable(orders) {
 
   orders.forEach(order => {
     // Build display values
-    const orderId    = `#${order.id}`;
-    const name       = [order.billing.first_name, order.billing.last_name].filter(Boolean).join(' ') || 'No Name';
-    const email      = order.billing.email || 'No Email';
+    const orderId    = `#${escapeHtml(order.id)}`;
+    const name       = escapeHtml([order.billing.first_name, order.billing.last_name].filter(Boolean).join(' ') || 'No Name');
+    const email      = escapeHtml(order.billing.email || 'No Email');
     const dateText   = order.date_created
-      ? new Date(order.date_created).toLocaleDateString('en-US', { month:'short', day:'numeric', year:'numeric' })
+      ? escapeHtml(new Date(order.date_created).toLocaleDateString('en-US', { month:'short', day:'numeric', year:'numeric' }))
       : 'No Date';
     const itemsHtml  = order.line_items.length
-      ? order.line_items.map(i => `<p>${i.quantity}× ${i.name}</p>`).join('')
+      ? order.line_items.map(i => `<p>${escapeHtml(i.quantity)}× ${escapeHtml(i.name)}</p>`).join('')
       : '<p>No Items</p>';
     const currentSt  = order.status || 'unknown';
-    const label      = getStatusLabel(currentSt);
+    const label      = escapeHtml(getStatusLabel(currentSt));
 
     // Build status dropdown
     const dropdown = `
@@ -62,7 +70,7 @@ function renderTable(orders) {
         </button>
         <ul class="dropdown-menu">
           ${['pending','processing','on-hold','in-transit','completed','returned','refunded','cancelled']
-            .map(st => `<li><a class="dropdown-item" href="#" data-status="${st}">${getStatusLabel(st)}</a></li>`)
+            .map(st => `<li><a class="dropdown-item" href="#" data-status="${st}">${escapeHtml(getStatusLabel(st))}</a></li>`)
             .join('')}
         </ul>
       </div>
@@ -70,7 +78,7 @@ function renderTable(orders) {
 
     // Pre-fill tracking code if present
     const existingMeta = order.meta_data.find(m => m.key === '_tracking_number');
-    const initTrack    = existingMeta ? existingMeta.value : '';
+    const initTrack    = existingMeta ? escapeHtml(existingMeta.value) : '';
 
     // Row HTML
     const row = `

--- a/assets/js/cJs/product-management.js
+++ b/assets/js/cJs/product-management.js
@@ -4,6 +4,14 @@ let currentPage = 1,
     totalPages  = 1,
     allProducts = [];
 
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 $(function(){
   // 1) Read ?page= or default to 1
   const params = new URLSearchParams(window.location.search);
@@ -70,18 +78,18 @@ function renderTable() {
   filtered.forEach(p => {
     $tb.append(`
       <tr>
-        <td>${p.id}</td>
-        <td><img src="${p.images?.[0]?.src || ''}" width="50"/></td>
-        <td>${p.name}</td>
-        <td>${p.stock_quantity ?? 'N/A'}</td>
-        <td>${p.price}</td>
+        <td>${escapeHtml(p.id)}</td>
+        <td><img src="${escapeHtml(p.images?.[0]?.src || '')}" width="50"/></td>
+        <td>${escapeHtml(p.name)}</td>
+        <td>${escapeHtml(p.stock_quantity ?? 'N/A')}</td>
+        <td>${escapeHtml(p.price)}</td>
         <td>
           <span class="badge ${p.stock_status === 'instock' ? 'bg-success' : 'bg-danger'}">
-            ${p.stock_status}
+            ${escapeHtml(p.stock_status)}
           </span>
         </td>
         <td>
-          <button class="btn btn-sm btn-primary edit-btn" data-id="${p.id}">
+          <button class="btn btn-sm btn-primary edit-btn" data-id="${escapeHtml(p.id)}">
             Edit
           </button>
         </td>

--- a/assets/js/cJs/shipments.js
+++ b/assets/js/cJs/shipments.js
@@ -4,6 +4,14 @@ let currentPage = 1,
     totalPages  = 1,
     PER_PAGE    = 20;
 
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 $(function(){
   // Initial load
   fetchShipments(1);
@@ -90,19 +98,19 @@ function fetchShipments(page = 1) {
       const $tbody = $('#shipmentsTable tbody').empty();
       list.forEach(s => {
         $tbody.append(`
-          <tr data-order-id="${s.order_id}">
-            <td>#${s.order_id}</td>
+          <tr data-order-id="${escapeHtml(s.order_id)}">
+            <td>#${escapeHtml(s.order_id)}</td>
             <td>
-              <input type="text" class="form-control form-control-sm provider-select" value="${s.provider || ''}">
+              <input type="text" class="form-control form-control-sm provider-select" value="${escapeHtml(s.provider || '')}">
             </td>
             <td>
-              <input type="text" class="form-control form-control-sm tracking-code-input" value="${s.tracking_no || ''}">
+              <input type="text" class="form-control form-control-sm tracking-code-input" value="${escapeHtml(s.tracking_no || '')}">
             </td>
             <td>
-              <input type="date" class="form-control form-control-sm eta-input" value="${s.eta || ''}">
+              <input type="date" class="form-control form-control-sm eta-input" value="${escapeHtml(s.eta || '')}">
             </td>
-            <td>${s.status}</td>
-            <td>${s.last_update}</td>
+            <td>${escapeHtml(s.status)}</td>
+            <td>${escapeHtml(s.last_update)}</td>
             <td>
               <button class="btn btn-sm btn-primary save-btn">
                 <i class="lni lni-checkmark-circle"></i>


### PR DESCRIPTION
## Summary
- add `escapeHtml` helper to key modules
- sanitize dynamic values when building HTML for orders, products, inventory, shipments, etc.

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684028be85e0832f8e2ee426137d6e96