### PR TITLE
Check WooCommerce response codes

### DIFF
--- a/assets/cPhp/update_shipment.php
+++ b/assets/cPhp/update_shipment.php
@@ -45,10 +45,19 @@ if (stripos($ctype, 'application/json') !== false) {
         CURLOPT_HTTPHEADER     => ['Content-Type: application/json'],
         CURLOPT_POSTFIELDS     => json_encode($payload)
     ]);
-    curl_exec($ch);
+    $resp   = curl_exec($ch);
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
 
-    echo json_encode(['success' => true]);
+    if ($status >= 200 && $status < 300) {
+        echo json_encode(['success' => true]);
+    } else {
+        http_response_code($status ?: 500);
+        echo json_encode([
+            'error'   => 'WooCommerce API error',
+            'details' => $resp
+        ]);
+    }
     exit;
 }
 
@@ -88,8 +97,18 @@ while (($row = fgetcsv($tmp)) !== false) {
         CURLOPT_HTTPHEADER     => ['Content-Type: application/json'],
         CURLOPT_POSTFIELDS     => json_encode($payload)
     ]);
-    curl_exec($ch);
+    $resp   = curl_exec($ch);
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
+    if ($status < 200 || $status >= 300) {
+        http_response_code($status ?: 500);
+        echo json_encode([
+            'error'   => 'WooCommerce API error',
+            'details' => $resp,
+            'order_id'=> $order_id
+        ]);
+        exit;
+    }
 }
 
 echo json_encode(['success' => true]);

--- a/assets/cPhp/upload_manifest.php
+++ b/assets/cPhp/upload_manifest.php
@@ -39,8 +39,18 @@ foreach ($rows as $row) {
     curl_setopt($ch, CURLOPT_USERPWD, "$consumer_key:$consumer_secret");
     curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
     curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
-    curl_exec($ch);
+    $resp   = curl_exec($ch);
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
+    if ($status < 200 || $status >= 300) {
+        http_response_code($status ?: 500);
+        echo json_encode([
+            'error'   => 'WooCommerce API error',
+            'details' => $resp,
+            'order_id'=> $orderId
+        ]);
+        exit;
+    }
 }
 
 echo json_encode(['success'=>true]);


### PR DESCRIPTION
## Summary
- inspect WooCommerce API response codes in shipment updates
- only return success when a 2xx code is received

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684028c0bbac832f8c6282d20a3144d7