### PR TITLE
Add invoice item rows and backend

### DIFF
--- a/assets/cPhp/create_invoice.php
+++ b/assets/cPhp/create_invoice.php
@@ -4,22 +4,27 @@ $file = __DIR__ . '/../data/invoices.json';
 $data = file_exists($file) ? json_decode(file_get_contents($file), true) : [];
 $raw = file_get_contents('php://input');
 $payload = json_decode($raw, true) ?: $_POST;
-$customer = trim($payload['customer'] ?? '');
-$amount   = isset($payload['amount']) ? (float)$payload['amount'] : 0;
-$status   = trim($payload['status'] ?? '');
-$date     = trim($payload['date'] ?? '');
-if($customer === '' || $status === '' || $date === ''){
+$items = isset($payload['items']) && is_array($payload['items']) ? $payload['items'] : [];
+if(!$items){
     http_response_code(400);
-    echo json_encode(['error' => 'Missing fields']);
+    echo json_encode(['error' => 'Missing items']);
     exit;
 }
+$customer = $items[0]['customerName'] ?? '';
+$amount   = 0;
+foreach($items as $it){
+    $amount += isset($it['totalCost']) ? (float)$it['totalCost'] : 0;
+}
+$status = 'Pending';
+$date   = date('Y-m-d');
 $id = count($data) ? max(array_column($data, 'id')) + 1 : 1;
 $data[] = [
     'id' => $id,
     'customer' => $customer,
     'amount' => $amount,
     'status' => $status,
-    'date' => $date
+    'date' => $date,
+    'items' => $items
 ];
 file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT));
 echo json_encode(['success'=>true,'id'=>$id]);

--- a/assets/cPhp/get_invoices.php
+++ b/assets/cPhp/get_invoices.php
@@ -8,6 +8,23 @@ if (!file_exists($dataFile)) {
     exit;
 }
 $invoices = json_decode(file_get_contents($dataFile), true);
+foreach($invoices as &$inv){
+    if(isset($inv['items']) && is_array($inv['items']) && $inv['items']){
+        if(!isset($inv['customer'])){
+            $inv['customer'] = $inv['items'][0]['customerName'] ?? '';
+        }
+        if(!isset($inv['amount'])){
+            $total = 0;
+            foreach($inv['items'] as $it){
+                $total += isset($it['totalCost']) ? (float)$it['totalCost'] : 0;
+            }
+            $inv['amount'] = $total;
+        }
+    }
+    $inv['status'] = $inv['status'] ?? 'Pending';
+    $inv['date'] = $inv['date'] ?? date('Y-m-d');
+}
+unset($inv);
 $page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
 $per_page = isset($_GET['per_page']) ? (int)$_GET['per_page'] : 20;
 $total = count($invoices);

--- a/assets/js/cJs/invoices.js
+++ b/assets/js/cJs/invoices.js
@@ -1,11 +1,22 @@
 // page-specific fetcher for Invoices
 let currentPage = 1;
 let totalPages  = 1;
+let invoiceItems = [];
 
 $(function(){
   fetchInvoices(1);
   $('#addInvoice').on('click', openAddInvoice);
   $('#saveInvoice').on('click', saveInvoice);
+  $('#addItem').on('click', addItem);
+  $('#itemsTable').on('click', '.remove-item', function(){
+    const idx = $(this).data('index');
+    removeItem(idx);
+  });
+  $('#itemsTable').on('input', 'input', function(){
+    const idx = $(this).closest('tr').data('index');
+    const field = $(this).data('field');
+    if(invoiceItems[idx]) invoiceItems[idx][field] = $(this).val();
+  });
   $('#invoiceTable').on('click', '.delete-invoice', function(){
     const id = $(this).data('id');
     deleteInvoice(id);
@@ -64,20 +75,58 @@ $(document).on('click', '.invoice-download', function(e) {
 });
 
 function openAddInvoice(){
-  $('#invCustomer').val('');
-  $('#invAmount').val('');
-  $('#invStatus').val('');
-  $('#invDate').val('');
+  invoiceItems = [];
+  addItem();
   new bootstrap.Modal($('#invoiceModal')).show();
 }
 
+function addItem(){
+  invoiceItems.push({
+    orderNumber: '',
+    trackingCode: '',
+    shippingProof: '',
+    customerName: '',
+    address: '',
+    countryName: '',
+    productName: '',
+    stripe: '',
+    productCost: '',
+    shippingCost: '',
+    totalCost: '',
+    note: ''
+  });
+  renderItems();
+}
+
+function removeItem(idx){
+  invoiceItems.splice(idx,1);
+  renderItems();
+}
+
+function renderItems(){
+  let html = '';
+  invoiceItems.forEach((item,i)=>{
+    html += `<tr data-index="${i}">
+      <td><input data-field="orderNumber" type="text" class="form-control" value="${item.orderNumber}"></td>
+      <td><input data-field="trackingCode" type="text" class="form-control" value="${item.trackingCode}"></td>
+      <td><input data-field="shippingProof" type="text" class="form-control" value="${item.shippingProof}"></td>
+      <td><input data-field="customerName" type="text" class="form-control" value="${item.customerName}"></td>
+      <td><input data-field="address" type="text" class="form-control" value="${item.address}"></td>
+      <td><input data-field="countryName" type="text" class="form-control" value="${item.countryName}"></td>
+      <td><input data-field="productName" type="text" class="form-control" value="${item.productName}"></td>
+      <td><input data-field="stripe" type="text" class="form-control" value="${item.stripe}"></td>
+      <td><input data-field="productCost" type="number" step="0.01" class="form-control" value="${item.productCost}"></td>
+      <td><input data-field="shippingCost" type="number" step="0.01" class="form-control" value="${item.shippingCost}"></td>
+      <td><input data-field="totalCost" type="number" step="0.01" class="form-control" value="${item.totalCost}"></td>
+      <td><input data-field="note" type="text" class="form-control" value="${item.note}"></td>
+      <td><button type="button" class="btn btn-sm btn-danger remove-item" data-index="${i}">Remove</button></td>
+    </tr>`;
+  });
+  $('#itemsTable tbody').html(html);
+}
+
 function saveInvoice(){
-  const payload = {
-    customer: $('#invCustomer').val(),
-    amount: parseFloat($('#invAmount').val()||0),
-    status: $('#invStatus').val(),
-    date: $('#invDate').val()
-  };
+  const payload = { items: invoiceItems };
   $.ajax({
     url:`${BASE_URL}/assets/cPhp/create_invoice.php`,
     method:'POST',

--- a/invoices.php
+++ b/invoices.php
@@ -59,29 +59,36 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 
     <!-- Invoice Modal -->
     <div class="modal fade" id="invoiceModal" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog">
+      <div class="modal-dialog modal-fullscreen">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title">Create Invoice</h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body">
-            <div class="mb-3">
-              <label class="form-label">Customer</label>
-              <input type="text" class="form-control" id="invCustomer">
+            <div class="table-responsive">
+              <table class="table table-bordered" id="itemsTable">
+                <thead class="table-light">
+                  <tr>
+                    <th>Order Number</th>
+                    <th>Tracking Code</th>
+                    <th>Shipping Proof</th>
+                    <th>Customer Name</th>
+                    <th>Address</th>
+                    <th>Country Name</th>
+                    <th>Product Name</th>
+                    <th>Stripe</th>
+                    <th>Product Cost</th>
+                    <th>Shipping Cost</th>
+                    <th>Total Cost</th>
+                    <th>Note</th>
+                    <th>Action</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
             </div>
-            <div class="mb-3">
-              <label class="form-label">Amount</label>
-              <input type="number" step="0.01" class="form-control" id="invAmount">
-            </div>
-            <div class="mb-3">
-              <label class="form-label">Status</label>
-              <input type="text" class="form-control" id="invStatus">
-            </div>
-            <div class="mb-3">
-              <label class="form-label">Date</label>
-              <input type="date" class="form-control" id="invDate">
-            </div>
+            <button type="button" class="btn btn-secondary" id="addItem">Add</button>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-primary" id="saveInvoice">Save</button>


### PR DESCRIPTION
## Summary
- support multi-line invoice entries
- show invoice item table in invoices modal
- manage invoice item rows in invoices.js
- store item arrays when creating invoices
- keep compatibility when listing invoices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840387ee69c832f8ff5e6a3ddd32681