### PR TITLE
Handle loader via global AJAX events

### DIFF
--- a/assets/js/cJs/pending_orders.js
+++ b/assets/js/cJs/pending_orders.js
@@ -23,7 +23,6 @@ function fetchPendingOrders(page) {
   currentPage = page;
 
   $.ajax({
-    beforeSend: window.showLoader,
     url: `${BASE_URL}/assets/cPhp/get_pending_orders.php`,
     method: 'GET',
     data: { page, per_page: PER_PAGE },
@@ -43,7 +42,6 @@ function fetchPendingOrders(page) {
       console.error('Error fetching pending orders:', textStatus, errorThrown);
       alert('❌ Could not load pending orders');
     },
-    complete: window.hideLoader
   });
 }
 
@@ -120,7 +118,6 @@ function renderTable(orders) {
     // Persist to server
     const $toggle = $btnGrp.find('.dropdown-toggle');
     $toggle.prop('disabled', true);
-    window.showLoader();
     $.ajax({
       url: `${BASE_URL}/assets/cPhp/update_order.php`,
       method: 'POST',
@@ -134,7 +131,6 @@ function renderTable(orders) {
     })
     .always(() => {
       $toggle.prop('disabled', false);
-      window.hideLoader();
     });
   });
 
@@ -147,7 +143,6 @@ function renderTable(orders) {
 
     const $btn = $form.find('button[type="submit"]');
     $btn.prop('disabled', true);
-    window.showLoader();
 
     $.ajax({
       url: `${BASE_URL}/assets/cPhp/update_order.php`,
@@ -162,7 +157,6 @@ function renderTable(orders) {
     })
     .always(() => {
       $btn.prop('disabled', false);
-      window.hideLoader();
     });
   });
 }

--- a/assets/js/cJs/shipments.js
+++ b/assets/js/cJs/shipments.js
@@ -30,7 +30,6 @@ $(function(){
     const fd = new FormData(this);
     const $btn = $(this).find('button[type="submit"]');
     $btn.prop('disabled', true);
-    window.showLoader();
     $.ajax({
       url: `${BASE_URL}/assets/cPhp/upload_manifest.php`,
       method: 'POST',
@@ -51,7 +50,6 @@ $(function(){
     })
     .always(() => {
       $btn.prop('disabled', false);
-      window.hideLoader();
     });
   });
 
@@ -65,7 +63,6 @@ $(function(){
 
     const $btn = $(this);
     $btn.prop('disabled', true);
-    window.showLoader();
 
     $.ajax({
       url: `${BASE_URL}/assets/cPhp/update_single_shipment.php`,
@@ -85,7 +82,6 @@ $(function(){
     })
     .always(() => {
       $btn.prop('disabled', false);
-      window.hideLoader();
     });
   });
 });
@@ -97,7 +93,6 @@ function fetchShipments(page = 1) {
   currentPage = page;
 
   $.ajax({
-    beforeSend: window.showLoader,
     url: `${BASE_URL}/assets/cPhp/get_shipments_summary.php`,
     method: 'GET',
     data: { page, per_page: PER_PAGE },
@@ -108,7 +103,6 @@ function fetchShipments(page = 1) {
       totalPages = parseInt(xhr.getResponseHeader('X-My-TotalPages'), 10) || 1;
       buildPagination();
       updateUrl(currentPage);
-      window.hideLoader();
     },
 
     success(list) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,6 +12,7 @@
     const el = document.getElementById('skeleton-loader')
     if (el) el.style.display = 'none'
   }
+$(document).ajaxStart(window.showLoader).ajaxStop(window.hideLoader);
 
   window.addEventListener('load', function () {
     if (skeleton.length) {


### PR DESCRIPTION
## Summary
- attach preloader helpers to global jQuery ajax events
- remove per-page AJAX show/hide calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68403f134498832f9b7e104642a9034f