### PR TITLE
Add product requests management

### DIFF
--- a/assets/cPhp/get_product_requests.php
+++ b/assets/cPhp/get_product_requests.php
@@ -1,0 +1,20 @@
+<?php
+// assets/cPhp/get_product_requests.php
+header('Content-Type: application/json; charset=utf-8');
+$file = __DIR__ . '/../data/product_requests.json';
+if (!file_exists($file)) {
+    echo json_encode([]);
+    exit;
+}
+$requests = json_decode(file_get_contents($file), true);
+
+$page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
+$per_page = isset($_GET['per_page']) ? (int)$_GET['per_page'] : 20;
+$total = count($requests);
+$total_pages = max(1, (int)ceil($total / $per_page));
+header('X-My-TotalPages: ' . $total_pages);
+$start = ($page - 1) * $per_page;
+$items = array_slice($requests, $start, $per_page);
+echo json_encode($items);
+exit;
+?>

--- a/assets/cPhp/submit_product_request.php
+++ b/assets/cPhp/submit_product_request.php
@@ -1,0 +1,30 @@
+<?php
+// assets/cPhp/submit_product_request.php
+header('Content-Type: application/json; charset=utf-8');
+$file = __DIR__ . '/../data/product_requests.json';
+$data = file_exists($file) ? json_decode(file_get_contents($file), true) : [];
+$raw = file_get_contents('php://input');
+$payload = json_decode($raw, true) ?: $_POST;
+$type = isset($payload['type']) ? $payload['type'] : '';
+$product = isset($payload['product']) ? trim($payload['product']) : '';
+$price = isset($payload['proposed_price']) ? (float)$payload['proposed_price'] : 0;
+$reason = isset($payload['reason']) ? trim($payload['reason']) : '';
+if(!$type || !$product){
+    http_response_code(400);
+    echo json_encode(['error'=>'Missing required fields']);
+    exit;
+}
+$id = count($data) ? max(array_column($data, 'id')) + 1 : 1;
+$data[] = [
+    'id'=>$id,
+    'type'=>$type,
+    'product'=>$product,
+    'proposed_price'=>$price,
+    'reason'=>$reason,
+    'status'=>'Pending',
+    'date'=>date('Y-m-d')
+];
+file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT));
+echo json_encode(['success'=>true,'id'=>$id]);
+exit;
+?>

--- a/assets/cPhp/update_product_request.php
+++ b/assets/cPhp/update_product_request.php
@@ -1,0 +1,25 @@
+<?php
+// assets/cPhp/update_product_request.php
+header('Content-Type: application/json; charset=utf-8');
+$file = __DIR__ . '/../data/product_requests.json';
+$data = file_exists($file) ? json_decode(file_get_contents($file), true) : [];
+$raw = file_get_contents('php://input');
+$payload = json_decode($raw, true) ?: $_POST;
+$id = isset($payload['id']) ? (int)$payload['id'] : 0;
+$status = isset($payload['status']) ? $payload['status'] : '';
+if(!$id || !in_array($status,['Approved','Rejected'])){
+    http_response_code(400);
+    echo json_encode(['error'=>'Invalid request']);
+    exit;
+}
+foreach($data as &$req){
+    if($req['id']==$id){
+        $req['status'] = $status;
+        break;
+    }
+}
+unset($req);
+file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT));
+echo json_encode(['success'=>true]);
+exit;
+?>

--- a/assets/data/product_requests.json
+++ b/assets/data/product_requests.json
@@ -1,0 +1,5 @@
+[
+  {"id":1,"type":"new_product","product":"Widget X","proposed_price":19.99,"reason":"Customer demand","status":"Pending","date":"2023-06-01"},
+  {"id":2,"type":"price_change","product":"SKU123","proposed_price":14.99,"reason":"Market trend","status":"Pending","date":"2023-06-05"},
+  {"id":3,"type":"new_product","product":"Gadget Y","proposed_price":29.5,"reason":"Add premium line","status":"Approved","date":"2023-06-10"}
+]

--- a/assets/js/cJs/product_requests.js
+++ b/assets/js/cJs/product_requests.js
@@ -1,0 +1,93 @@
+// JS for product requests page
+let currentPage = 1;
+let totalPages  = 1;
+
+$(function(){
+  fetchRequests(1);
+  $('#newProductBtn').on('click', function(){
+    $('#requestForm')[0].reset();
+    $('#requestType').val('new_product');
+    $('#requestModal').modal('show');
+  });
+  $('#priceChangeBtn').on('click', function(){
+    $('#requestForm')[0].reset();
+    $('#requestType').val('price_change');
+    $('#requestModal').modal('show');
+  });
+  $('#saveRequest').on('click', submitRequest);
+});
+
+function fetchRequests(page=1){
+  currentPage = page;
+  $.ajax({
+    url:`${BASE_URL}/assets/cPhp/get_product_requests.php`,
+    method:'GET',
+    data:{page, per_page:20},
+    dataType:'json',
+    complete(xhr){
+      totalPages = parseInt(xhr.getResponseHeader('X-My-TotalPages')) || 1;
+      buildPagination();
+    },
+    success(list){
+      let html='';
+      list.forEach(r=>{
+        html += `<tr>
+          <td>${r.id}</td>
+          <td>${r.type.replace('_',' ')}</td>
+          <td>${r.product}</td>
+          <td>$${r.proposed_price}</td>
+          <td>${r.reason || ''}</td>
+          <td><span class="badge ${r.status==='Approved'?'bg-success':r.status==='Rejected'?'bg-danger':'bg-secondary'}">${r.status}</span></td>
+          <td>
+            <button class="btn btn-sm btn-success approve-btn" data-id="${r.id}">Approve</button>
+            <button class="btn btn-sm btn-danger reject-btn" data-id="${r.id}">Reject</button>
+          </td>
+        </tr>`;
+      });
+      $('#requestsTable tbody').html(html);
+    }
+  });
+}
+
+function submitRequest(){
+  const payload = {
+    type: $('#requestType').val(),
+    product: $('#productName').val(),
+    proposed_price: $('#proposedPrice').val(),
+    reason: $('#requestReason').val()
+  };
+  $.ajax({
+    url:`${BASE_URL}/assets/cPhp/submit_product_request.php`,
+    method:'POST',
+    contentType:'application/json',
+    data: JSON.stringify(payload)
+  }).done(()=>{
+    $('#requestModal').modal('hide');
+    fetchRequests(1);
+  }).fail(xhr=>{
+    alert('Submit failed: ' + (xhr.responseJSON?.error || xhr.statusText));
+  });
+}
+
+$(document).on('click', '.approve-btn', function(){
+  const id = $(this).data('id');
+  updateStatus(id,'Approved');
+});
+
+$(document).on('click', '.reject-btn', function(){
+  const id = $(this).data('id');
+  updateStatus(id,'Rejected');
+});
+
+function updateStatus(id,status){
+  $.ajax({
+    url:`${BASE_URL}/assets/cPhp/update_product_request.php`,
+    method:'POST',
+    contentType:'application/json',
+    data: JSON.stringify({id, status})
+  }).done(()=> fetchRequests(currentPage))
+    .fail(xhr=> alert('Update failed: ' + (xhr.responseJSON?.error || xhr.statusText)));
+}
+
+// expose fetcher for pagination
+window.fetchPendingOrders = fetchRequests;

--- a/assets/js/cJs/sidebar.js
+++ b/assets/js/cJs/sidebar.js
@@ -79,6 +79,7 @@ const sidebarHTML = `
         <ul id="ddmenu_products" class="collapse dropdown-nav">
           <li><a href="product-management.php">Product Management</a></li>
           <li><a href="inventory-management.php">Inventory Management</a></li>
+          <li><a href="product-requests.php">Product Requests</a></li>
         </ul>
       </li>
 

--- a/product-requests.php
+++ b/product-requests.php
@@ -1,0 +1,102 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/server-config.php';
+$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="shortcut icon" href="assets/images/favicon.svg" type="image/x-icon" />
+  <title>Tharavix | Product Requests</title>
+  <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="assets/css/lineicons.css" />
+  <link rel="stylesheet" href="assets/css/materialdesignicons.min.css" />
+  <link rel="stylesheet" href="assets/css/main.css" />
+  <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+</head>
+<body>
+  <div id="skeleton-loader"><div class="skeleton-block"></div></div>
+  <aside class="sidebar-nav-wrapper">
+    <script src="assets/js/cJs/sidebar.js"></script>
+  </aside>
+  <div class="overlay"></div>
+  <main class="main-wrapper">
+    <header class="header">
+      <script src="assets/js/cJs/header.js"></script>
+      <script src="assets/js/cJs/menuToggle.js"></script>
+    </header>
+    <section class="table-components">
+      <div class="container-fluid">
+        <div class="title-wrapper pt-30 mb-3 d-flex justify-content-between align-items-center">
+          <h2>Product Requests</h2>
+          <div>
+            <button id="newProductBtn" class="main-btn primary-btn btn-hover btn-sm me-2">New Product</button>
+            <button id="priceChangeBtn" class="main-btn primary-btn btn-hover btn-sm">Price Change</button>
+          </div>
+        </div>
+        <div class="card-style mb-30">
+          <div class="table-responsive">
+            <table class="table" id="requestsTable">
+              <thead class="table-light">
+                <tr>
+                  <th>ID</th>
+                  <th>Type</th>
+                  <th>Product</th>
+                  <th>Proposed Price</th>
+                  <th>Reason</th>
+                  <th>Status</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <nav class="p-3"><ul class="base-pagination pagination"></ul></nav>
+        </div>
+      </div>
+    </section>
+
+    <!-- Request Modal -->
+    <div class="modal fade" id="requestModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Submit Request</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <form id="requestForm">
+              <input type="hidden" id="requestType" value="new_product" />
+              <div class="mb-3">
+                <label class="form-label">Product / SKU</label>
+                <input type="text" class="form-control" id="productName" required />
+              </div>
+              <div class="mb-3">
+                <label class="form-label">Proposed Price</label>
+                <input type="number" step="0.01" class="form-control" id="proposedPrice" />
+              </div>
+              <div class="mb-3">
+                <label class="form-label">Reason</label>
+                <textarea class="form-control" id="requestReason"></textarea>
+              </div>
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" id="saveRequest">Submit</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <footer class="footer">
+      <script src="assets/js/cJs/footer.js"></script>
+    </footer>
+  </main>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="assets/js/bootstrap.bundle.min.js"></script>
+  <script src="assets/js/main.js"></script>
+  <script src="assets/js/cJs/product_requests.js"></script>
+  <script src="assets/js/cJs/pagination.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add page to handle product requests
- implement JS helpers for submitting and updating requests
- add backend endpoints for requests CRUD
- show link in sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684041702758832f8ef818012f32b684