### PR TITLE
Add Discontinued status support

### DIFF
--- a/assets/cPhp/get_products.php
+++ b/assets/cPhp/get_products.php
@@ -30,6 +30,13 @@ $page     = isset($_GET['page'])     ? (int)$_GET['page']     : 1;
 $per_page = isset($_GET['per_page']) ? (int)$_GET['per_page'] : 20;
 $endpoint = "/wp-json/wc/v3/products?page={$page}&per_page={$per_page}";
 
+// Optional stock status filter
+$status = $_GET['status'] ?? '';
+$allowed = ['instock', 'outofstock', 'discontinued'];
+if ($status && in_array($status, $allowed, true)) {
+    $endpoint .= "&stock_status={$status}";
+}
+
 header('Content-Type: application/json; charset=utf-8');
 echo callWooAPI($store_url, $endpoint, $consumer_key, $consumer_secret);
 exit;

--- a/assets/cPhp/update_product.php
+++ b/assets/cPhp/update_product.php
@@ -20,7 +20,16 @@ if (!$id) {
 $fields = [];
 if (isset($data['price']))  $fields['regular_price'] = (string)$data['price'];
 if (isset($data['stock']))  $fields['stock_quantity'] = (int)$data['stock'];
-if (isset($data['status'])) $fields['stock_status']   = $data['status'];
+if (isset($data['status'])) {
+    $allowedStatuses = ['instock', 'outofstock', 'discontinued'];
+    if (!in_array($data['status'], $allowedStatuses, true)) {
+        http_response_code(400);
+        header('Content-Type: application/json; charset=utf-8');
+        echo json_encode(['error' => 'Invalid status']);
+        exit;
+    }
+    $fields['stock_status'] = $data['status'];
+}
 
 if (empty($fields)) {
     http_response_code(400);

--- a/assets/js/cJs/product-management.js
+++ b/assets/js/cJs/product-management.js
@@ -84,7 +84,13 @@ function renderTable() {
         <td>${escapeHtml(p.stock_quantity ?? 'N/A')}</td>
         <td>${escapeHtml(p.price)}</td>
         <td>
-          <span class="badge ${p.stock_status === 'instock' ? 'bg-success' : 'bg-danger'}">
+          <span class="badge ${
+            p.stock_status === 'instock'
+              ? 'bg-success'
+              : p.stock_status === 'discontinued'
+              ? 'bg-secondary'
+              : 'bg-danger'
+          }">
             ${escapeHtml(p.stock_status)}
           </span>
         </td>

--- a/product-management.php
+++ b/product-management.php
@@ -68,6 +68,7 @@
                     <option value="">All</option>
                     <option value="instock">In Stock</option>
                     <option value="outofstock">Out of Stock</option>
+                    <option value="discontinued">Discontinued</option>
                   </select>
                 </div>
               </div>
@@ -127,6 +128,7 @@
                 <select id="edit-status" name="status" class="form-select">
                   <option value="instock">In Stock</option>
                   <option value="outofstock">Out of Stock</option>
+                  <option value="discontinued">Discontinued</option>
                 </select>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- include a Discontinued option in the product management filters and edit form
- colour-code discontinued products in the table
- validate and pass the new status in product endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840416d8588832fa717d2809402f538