### PR TITLE
Fix duplicate API calls in get_product

### DIFF
--- a/assets/cPhp/get_product.php
+++ b/assets/cPhp/get_product.php
@@ -27,65 +27,59 @@ if (!$id) {
     exit;
 }
 
-$endpoint = "/wp-json/wc/v3/products/{$id}?context=edit";
 header('Content-Type: application/json; charset=utf-8');
 
 // Fetch product from WooCommerce
-$raw = callWooAPI($store_url, "/wp-json/wc/v3/products/{$id}", $consumer_key, $consumer_secret);
-$product = json_decode($raw, true);
+$resp    = callWooAPI($store_url, "/wp-json/wc/v3/products/{$id}", $consumer_key, $consumer_secret);
+$product = json_decode($resp, true);
+
+if (!is_array($product)) {
+    echo $resp;
+    exit;
+}
+
+// Add variant attributes when product is variable
+if (($product['type'] ?? '') === 'variable') {
+    $varResp = callWooAPI(
+        $store_url,
+        "/wp-json/wc/v3/products/{$id}/variations?per_page=100",
+        $consumer_key,
+        $consumer_secret
+    );
+    $vars = json_decode($varResp, true);
+    if (is_array($vars)) {
+        $product['variant_attributes'] = array_map(function ($v) {
+            return $v['attributes'];
+        }, $vars);
+    }
+}
+
+// Extract custom metadata
+if (!empty($product['meta_data']) && is_array($product['meta_data'])) {
+    foreach ($product['meta_data'] as $m) {
+        if ($m['key'] === '_packaging_info_url') {
+            $product['packaging_info_url'] = $m['value'];
+        }
+        if ($m['key'] === '_safety_sheet_url') {
+            $product['safety_sheet_url'] = $m['value'];
+        }
+    }
+}
 
 // Attach local restock_eta value
 $etaFile = __DIR__ . '/../data/restock_eta.json';
 if (file_exists($etaFile)) {
     $data = json_decode(file_get_contents($etaFile), true);
-    foreach ($data as $e) {
-        if (isset($e['id']) && (int)$e['id'] === $id) {
-            $product['restock_eta'] = $e['restock_eta'] ?? null;
-            break;
+    if (is_array($data)) {
+        foreach ($data as $e) {
+            if (isset($e['id']) && (int)$e['id'] === $id) {
+                $product['restock_eta'] = $e['restock_eta'] ?? null;
+                break;
+            }
         }
     }
 }
 
 echo json_encode($product);
-
-
-$json = callWooAPI($store_url, "/wp-json/wc/v3/products/{$id}", $consumer_key, $consumer_secret);
-$product = json_decode($json, true);
-
-if (is_array($product)) {
-    if (($product['type'] ?? '') === 'variable') {
-        $varResp = callWooAPI(
-            $store_url,
-            "/wp-json/wc/v3/products/{$id}/variations?per_page=100",
-            $consumer_key,
-            $consumer_secret
-        );
-        $vars = json_decode($varResp, true);
-        if (is_array($vars)) {
-            $product['variant_attributes'] = array_map(function($v){
-                return $v['attributes'];
-            }, $vars);
-        }
-    }
-    // extract custom metadata
-    if (!empty($product['meta_data']) && is_array($product['meta_data'])) {
-        foreach ($product['meta_data'] as $m) {
-            if ($m['key'] === '_packaging_info_url') {
-                $product['packaging_info_url'] = $m['value'];
-            }
-            if ($m['key'] === '_safety_sheet_url') {
-                $product['safety_sheet_url'] = $m['value'];
-            }
-        }
-    }
-    echo json_encode($product);
-    exit;
-}
-
-echo $json;
-
-echo callWooAPI($store_url, $endpoint, $consumer_key, $consumer_secret);
-
-
 exit;
 ?>


### PR DESCRIPTION
## Summary
- simplify the get_product.php script
- remove duplicate API calls and extra echo statements
- output a single JSON payload containing metadata and restock ETA

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404f2a37ec832f957cd925ffb8ab13