### PR TITLE
Fix duplicate product request endpoint

### DIFF
--- a/assets/cPhp/get_product_requests.php
+++ b/assets/cPhp/get_product_requests.php
@@ -3,31 +3,28 @@
 // portal/assets/cPhp/get_product_requests.php
 require_once __DIR__ . '/db.php';
 
-$res  = $db->query('SELECT * FROM product_requests ORDER BY requested_at DESC');
+header('Content-Type: application/json; charset=utf-8');
+
+$page     = isset($_GET['page']) ? max(1, (int)$_GET['page']) : 1;
+$per_page = isset($_GET['per_page']) ? max(1, (int)$_GET['per_page']) : 20;
+
+// Determine total rows and pages
+$total_rows  = (int)$db->querySingle('SELECT COUNT(*) FROM product_requests');
+$total_pages = max(1, (int)ceil($total_rows / $per_page));
+header('X-My-TotalPages: ' . $total_pages);
+
+// Fetch paginated results
+$offset = ($page - 1) * $per_page;
+$stmt   = $db->prepare('SELECT * FROM product_requests ORDER BY requested_at DESC LIMIT :limit OFFSET :offset');
+$stmt->bindValue(':limit',  $per_page, SQLITE3_INTEGER);
+$stmt->bindValue(':offset', $offset,   SQLITE3_INTEGER);
+$res    = $stmt->execute();
+
 $rows = [];
 while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
     $rows[] = $row;
 }
 
-header('Content-Type: application/json; charset=utf-8');
 echo json_encode($rows);
-
-// assets/cPhp/get_product_requests.php
-header('Content-Type: application/json; charset=utf-8');
-$file = __DIR__ . '/../data/product_requests.json';
-if (!file_exists($file)) {
-    echo json_encode([]);
-    exit;
-}
-$requests = json_decode(file_get_contents($file), true);
-
-$page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
-$per_page = isset($_GET['per_page']) ? (int)$_GET['per_page'] : 20;
-$total = count($requests);
-$total_pages = max(1, (int)ceil($total / $per_page));
-header('X-My-TotalPages: ' . $total_pages);
-$start = ($page - 1) * $per_page;
-$items = array_slice($requests, $start, $per_page);
-echo json_encode($items);
 exit;
 ?>


### PR DESCRIPTION
## Summary
- clean up `get_product_requests.php`
- use only SQLite and implement pagination

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404f2870ec832f85839ea484950940