### PR TITLE
Restrict shipments summary to processing orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,6 @@ Two PHP scripts handle shipment updates:
 - `assets/cPhp/update_single_shipment.php` – Accepts a JSON body containing an
   `order_id` plus optional `provider`, `tracking_no` and `eta` values. It updates
   a single WooCommerce order and is used when editing rows in `shipments.js`.
+- `assets/cPhp/get_shipments_summary.php` – Returns orders with
+  `status=processing`. Results are paginated with `page` and `per_page`
+  parameters.

--- a/assets/cPhp/get_shipments_summary.php
+++ b/assets/cPhp/get_shipments_summary.php
@@ -43,8 +43,8 @@ function callWoo($endpoint) {
     return json_decode($body, true);
 }
 
-// Fetch orders
-$endpoint = "/wp-json/wc/v3/orders?page={$page}&per_page={$per_page}";
+// Fetch orders restricted to processing status
+$endpoint = "/wp-json/wc/v3/orders?status=processing&page={$page}&per_page={$per_page}";
 $orders   = callWoo($endpoint);
 
 header('Content-Type: application/json; charset=utf-8');

--- a/assets/js/cJs/logistics_orders.js
+++ b/assets/js/cJs/logistics_orders.js
@@ -10,6 +10,7 @@ $(function(){
   fetchLogisticsOrders(p);
 });
 
+// Fetch orders currently in the "processing" state
 function fetchLogisticsOrders(page=1){
   currentPage = page;
   $.ajax({

--- a/assets/js/cJs/shipments.js
+++ b/assets/js/cJs/shipments.js
@@ -89,6 +89,7 @@ $(function(){
 /**
  * Fetch and render the shipments page
  */
+// Load only orders that are still processing
 function fetchShipments(page = 1) {
   currentPage = page;
 


### PR DESCRIPTION
## Summary
- filter get_shipments_summary.php for status=processing
- note the status filter in the README
- clarify JS that uses this summary endpoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68405aa3fc38832f82e4b2cf6e125b95