### PR TITLE
Add on hold status support

### DIFF
--- a/assets/cPhp/get_on_hold_orders.php
+++ b/assets/cPhp/get_on_hold_orders.php
@@ -1,0 +1,54 @@
+<?php
+// get_on_hold_orders.php
+// Fetches WooCommerce orders with status=on-hold
+// and re-emits the X-My-TotalPages header so JS can paginate correctly.
+
+require_once(__DIR__ . '/master-api.php');
+
+function callWooAPI($baseUrl, $endpoint, $ck, $cs) {
+    $url = rtrim($baseUrl, '/') . $endpoint;
+    $ch  = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HEADER,         true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Authorization: Basic ' . base64_encode("$ck:$cs"),
+        'Content-Type: application/json',
+    ]);
+
+    $raw = curl_exec($ch);
+    if (curl_errno($ch)) {
+        http_response_code(500);
+        echo json_encode(['error' => curl_error($ch)]);
+        exit;
+    }
+
+    $hsize  = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+    $header = substr($raw, 0, $hsize);
+    $body   = substr($raw, $hsize);
+    curl_close($ch);
+
+    if (preg_match('/^X-WP-TotalPages:\s*(\d+)/mi', $header, $matches)) {
+        header('X-My-TotalPages: ' . $matches[1]);
+    }
+
+    return $body;
+}
+
+$page      = isset($_GET['page'])     ? (int) $_GET['page']     : 1;
+$per_page  = isset($_GET['per_page']) ? (int) $_GET['per_page'] : 20;
+$order_id  = isset($_GET['order_id']) ? trim($_GET['order_id']) : '';
+
+$endpoint = "/wp-json/wc/v3/orders?status=on-hold&page={$page}&per_page={$per_page}";
+if ($order_id !== '') {
+    $endpoint .= '&search=' . urlencode($order_id);
+}
+
+header('Content-Type: application/json; charset=utf-8');
+echo callWooAPI(
+    $store_url,
+    $endpoint,
+    $consumer_key,
+    $consumer_secret
+);
+exit;
+?>

--- a/assets/js/cJs/on_hold_orders.js
+++ b/assets/js/cJs/on_hold_orders.js
@@ -1,0 +1,159 @@
+// assets/js/cJs/on_hold_orders.js
+
+let currentPage = 1;
+let totalPages  = 1;
+const PER_PAGE  = 20;
+
+$(document).ready(function() {
+  const params   = new URLSearchParams(window.location.search);
+  const pageParm = parseInt(params.get('page'), 10) || 1;
+  fetchOnHoldOrders(pageParm);
+});
+
+function fetchOnHoldOrders(page) {
+  currentPage = page;
+
+  $.ajax({
+    url: `${BASE_URL}/assets/cPhp/get_on_hold_orders.php`,
+    method: 'GET',
+    data: { page, per_page: PER_PAGE },
+    dataType: 'json',
+    success(list, _, xhr) {
+      renderTable(list);
+      totalPages = parseInt(xhr.getResponseHeader('X-My-TotalPages'), 10) || 1;
+      buildPagination('.base-pagination', totalPages, currentPage, fetchOnHoldOrders);
+      updateUrl(page);
+    },
+    error(xhr, status, err) {
+      console.error('Error fetching on-hold orders:', status, err);
+      alert('❌ Could not load on-hold orders');
+    }
+  });
+}
+
+function renderTable(orders) {
+  const $tbody = $('table tbody').empty();
+
+  orders.forEach(order => {
+    const orderId    = `#${escapeHtml(order.id)}`;
+    const name       = escapeHtml([order.billing.first_name, order.billing.last_name].filter(Boolean).join(' ') || 'No Name');
+    const email      = escapeHtml(order.billing.email || 'No Email');
+    const dateText   = order.date_created
+      ? escapeHtml(new Date(order.date_created).toLocaleDateString('en-US', { month:'short', day:'numeric', year:'numeric' }))
+      : 'No Date';
+    const itemsHtml  = order.line_items.length
+      ? order.line_items.map(i => `<p>${escapeHtml(i.quantity)}× ${escapeHtml(i.name)}</p>`).join('')
+      : '<p>No Items</p>';
+    const currentSt  = order.status || 'unknown';
+    const label      = escapeHtml(getStatusLabel(currentSt));
+
+    const dropdown = `
+      <div class="btn-group">
+        <button class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown">
+          <span class="status-text">${label}</span>
+        </button>
+        <ul class="dropdown-menu">
+          ${['pending','processing','on-hold','in-transit','completed','returned','refunded','cancelled']
+            .map(st => `<li><a class="dropdown-item" href="#" data-status="${st}">${escapeHtml(getStatusLabel(st))}</a></li>`)
+            .join('')}
+        </ul>
+      </div>
+    `;
+
+    const existingMeta = order.meta_data.find(m => m.key === '_tracking_number');
+    const initTrack    = existingMeta ? escapeHtml(existingMeta.value) : '';
+
+    const row = `
+      <tr data-order-id="${order.id}">
+        <td>${orderId} ${name}</td>
+        <td><a href="mailto:${email}">${email}</a></td>
+        <td>${dateText}</td>
+        <td class="items-col">${itemsHtml}</td>
+        <td>${dropdown}</td>
+        <td>
+          <form class="tracking-form d-flex">
+            <input type="text" name="tracking_code" class="form-control form-control-sm tracking-code-input"
+                   placeholder="Tracking code" value="${initTrack}">
+            <button type="submit" class="btn btn-link p-0 ms-2" title="Save">
+              <i class="lni lni-checkmark-circle" style="font-size:1.4rem;color:#28a745"></i>
+            </button>
+          </form>
+        </td>
+      </tr>
+    `;
+
+    $tbody.append(row);
+  });
+
+  $tbody.find('.dropdown-item').click(function(e) {
+    e.preventDefault();
+    const $li    = $(this);
+    const newSt  = $li.data('status');
+    const $btnGrp= $li.closest('.btn-group');
+    const $btn   = $btnGrp.find('.status-text');
+    const orderId= $li.closest('tr').data('order-id');
+
+    $btn.text(getStatusLabel(newSt));
+
+    const $toggle = $btnGrp.find('.dropdown-toggle');
+    $toggle.prop('disabled', true);
+    $.ajax({
+      url: `${BASE_URL}/assets/cPhp/update_order.php`,
+      method: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify({ order_id: orderId, status: newSt })
+    })
+    .done(() => fetchOnHoldOrders(currentPage))
+    .fail(xhr => {
+      console.error(xhr.responseText);
+      alert('❌ Status update failed');
+    })
+    .always(() => {
+      $toggle.prop('disabled', false);
+    });
+  });
+
+  $tbody.find('.tracking-form').submit(function(e) {
+    e.preventDefault();
+    const $form      = $(this);
+    const codeVal    = $form.find('[name="tracking_code"]').val().trim();
+    const orderId    = $form.closest('tr').data('order-id');
+
+    const $btn = $form.find('button[type="submit"]');
+    $btn.prop('disabled', true);
+
+    $.ajax({
+      url: `${BASE_URL}/assets/cPhp/update_order.php`,
+      method: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify({ order_id: orderId, tracking_code: codeVal })
+    })
+    .done(() => fetchOnHoldOrders(currentPage))
+    .fail(xhr => {
+      console.error(xhr.responseText);
+      alert('❌ Failed to save tracking code');
+    })
+    .always(() => {
+      $btn.prop('disabled', false);
+    });
+  });
+}
+
+function getStatusLabel(key) {
+  const map = {
+    pending:    'New Order',
+    processing: 'Processing',
+    'on-hold':  'On Hold',
+    'in-transit':'In Transit',
+    completed:  'Delivered',
+    returned:   'Returned',
+    refunded:   'Refunded',
+    cancelled:  'Cancelled'
+  };
+  return map[key] || key;
+}
+
+function updateUrl(page) {
+  const newUrl = `${window.location.pathname}?page=${page}`;
+  window.history.pushState({}, '', newUrl);
+}

--- a/assets/js/cJs/orders.js
+++ b/assets/js/cJs/orders.js
@@ -5,6 +5,7 @@ const endpointMap = {
   new:          'get_processing_orders.php',
   pending:      'get_pending_orders.php',
   processing:   'get_processing_orders.php',
+  'on-hold':    'get_on_hold_orders.php',
   'in-transit': 'get_in_transit_orders.php',
   completed:    'get_delivered_orders.php',
   returned:     'get_returned_orders.php',
@@ -82,6 +83,7 @@ function renderOrders(orders) {
 window.fetchNewOrders        = page => (currentStatus='new',        fetchOrders(page));
 window.fetchPendingOrders    = page => (currentStatus='pending',    fetchOrders(page));
 window.fetchProcessingOrders = page => (currentStatus='processing', fetchOrders(page));
+window.fetchOnHoldOrders    = page => (currentStatus='on-hold',    fetchOrders(page));
 window.fetchInTransitOrders  = page => (currentStatus='in-transit', fetchOrders(page));
 window.fetchDeliveredOrders  = page => (currentStatus='completed',  fetchOrders(page));
 window.fetchReturnedOrders   = page => (currentStatus='returned',   fetchOrders(page));

--- a/assets/js/cJs/sidebar.js
+++ b/assets/js/cJs/sidebar.js
@@ -38,6 +38,7 @@ const sidebarHTML = `
         <ul id="ddmenu_orders" class="collapse dropdown-nav">
           <li><a href="new-orders.php">New Orders</a></li>
           <li><a href="pending-orders.php">Pending Orders</a></li>
+          <li><a href="on-hold-orders.php">On-Hold Orders</a></li>
           <li><a href="in-transit-orders.php">In-Transit Orders</a></li>
           <li><a href="cancelled-orders.php">Cancelled Orders</a></li>
           <li><a href="delivered-orders.php">Delivered Orders</a></li>

--- a/on-hold-orders.php
+++ b/on-hold-orders.php
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="shortcut icon" href="assets/images/favicon.svg" type="image/x-icon" />
+    <title>Tharavix | On-Hold Orders</title>
+    <!-- ========== CSS Files ========== -->
+    <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="assets/css/lineicons.css" />
+    <link rel="stylesheet" href="assets/css/materialdesignicons.min.css" />
+    <link rel="stylesheet" href="assets/css/fullcalendar.css" />
+    <link rel="stylesheet" href="assets/css/main.css" />
+    <!-- Inline CSS -->
+    <style>
+      td {
+        white-space: normal;
+        vertical-align: top;
+      }
+      .items-col p {
+        margin: 0;
+      }
+      .card-style .dropdown-toggle {
+        border: none;
+        background: #ff000026;
+        color: red;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="skeleton-loader"><div class="skeleton-block"></div></div>
+    <aside class="sidebar-nav-wrapper">
+      <script src="assets/js/cJs/sidebar.js"></script>
+    </aside>
+    <div class="overlay"></div>
+    <main class="main-wrapper">
+      <header class="header">
+        <script src="assets/js/cJs/header.js"></script>
+        <script src="assets/js/cJs/menuToggle.js"></script>
+      </header>
+      <section class="table-components">
+        <div class="container-fluid">
+          <div class="title-wrapper pt-30">
+            <div class="row align-items-center">
+              <div class="col-md-6">
+                <div class="title">
+                  <h2>On-Hold Orders</h2>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <!-- Optional filters/actions -->
+              </div>
+            </div>
+          </div>
+          <div class="tables-wrapper">
+            <div class="row">
+              <div class="col-lg-12">
+                <div class="card-style mb-30">
+                  <h6 class="mb-10">Data Table</h6>
+                  <div class="table-responsive">
+                    <table class="table align-middle">
+                      <thead>
+                        <tr>
+                          <th><h6>Order</h6></th>
+                          <th><h6>Email</h6></th>
+                          <th><h6>Date</h6></th>
+                          <th><h6>Order Items</h6></th>
+                          <th><h6>Status</h6></th>
+                          <th><h6>Update / Assign</h6></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <!-- Injected table rows -->
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Pagination Navigation -->
+            <nav>
+              <ul class="base-pagination pagination">
+                <!-- Dynamic pagination will be built in pagination.js -->
+              </ul>
+            </nav>
+          </div>
+        </div>
+      </section>
+      <footer class="footer">
+        <script src="assets/js/cJs/footer.js"></script>
+      </footer>
+    </main>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="assets/js/bootstrap.bundle.min.js"></script>
+    <script src="assets/js/Chart.min.js"></script>
+    <script src="assets/js/dynamic-pie-chart.js"></script>
+    <script src="assets/js/moment.min.js"></script>
+    <script src="assets/js/fullcalendar.js"></script>
+    <script src="assets/js/jvectormap.min.js"></script>
+    <script src="assets/js/world-merc.js"></script>
+    <script src="assets/js/polyfill.js"></script>
+    <script src="assets/js/main.js"></script>
+    <script>
+      const BASE_URL = "<?php include 'assets/cPhp/server-config.php'; echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+    </script>
+    <script src="assets/js/cJs/on_hold_orders.js"></script>
+    <script src="assets/js/cJs/pagination.js"></script>
+  </body>
+</html>

--- a/orders.php
+++ b/orders.php
@@ -40,6 +40,7 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
               <option value="new">New Orders</option>
               <option value="pending">Pending Orders</option>
               <option value="processing">Processing Orders</option>
+              <option value="on-hold">On-Hold Orders</option>
               <option value="in-transit">Orders in Transit</option>
               <option value="completed">Delivered Orders</option>
               <option value="returned">Returned Orders</option>


### PR DESCRIPTION
## Summary
- fetch on-hold orders via new PHP endpoint
- display an On-Hold Orders page
- include `on-hold` in sidebar and status filter
- wire up `fetchOnHoldOrders` in orders.js for generic table

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68408603c720832faee4cb3f9915a585