### PR TITLE
Fix missing escapeHtml function

### DIFF
--- a/assets/js/cJs/on_hold_orders.js
+++ b/assets/js/cJs/on_hold_orders.js
@@ -4,6 +4,14 @@ let currentPage = 1;
 let totalPages  = 1;
 const PER_PAGE  = 20;
 
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 $(document).ready(function() {
   const params   = new URLSearchParams(window.location.search);
   const pageParm = parseInt(params.get('page'), 10) || 1;


### PR DESCRIPTION
## Summary
- ensure `escapeHtml` is available in `on_hold_orders.js`

## Testing
- `npm install --no-progress`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684087bb1f78832fa57cbe547df978aa