### PR TITLE
Enhance invoice PDF generation

### DIFF
--- a/assets/cPhp/download_invoice.php
+++ b/assets/cPhp/download_invoice.php
@@ -7,6 +7,23 @@ require_once __DIR__ . '/master-api.php';
 // Use TCPDF for generating PDFs from HTML templates
 require_once '/usr/share/php/tcpdf/tcpdf.php';
 
+function output_pdf($html, $localFile, $id){
+    $pdf = new TCPDF();
+    $pdf->SetCreator('Delivery Portal');
+    $pdf->SetAuthor('Delivery Portal');
+    $pdf->SetTitle('Invoice #' . $id);
+    $pdf->SetMargins(15, 15, 15);
+    $pdf->AddPage();
+    $pdf->writeHTML($html, true, false, true, false, '');
+    $pdf->Output($localFile, 'F');
+
+    $pdfContent = file_get_contents($localFile);
+    header('Content-Type: application/pdf');
+    header('Content-Disposition: attachment; filename="invoice-' . $id . '.pdf"');
+    header('Content-Length: ' . strlen($pdfContent));
+    echo $pdfContent;
+}
+
 $id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 if (!$id) {
     http_response_code(400);
@@ -25,6 +42,76 @@ if (file_exists($localFile)) {
     header('Content-Disposition: attachment; filename="invoice-' . $id . '.pdf"');
     readfile($localFile);
     exit;
+}
+
+// Try to load invoice from JSON store
+$jsonFile = __DIR__ . '/../data/invoices.json';
+if (file_exists($jsonFile)) {
+    $invoices = json_decode(file_get_contents($jsonFile), true);
+    if (is_array($invoices)) {
+        foreach ($invoices as $inv) {
+            if ((int)($inv['id'] ?? 0) === $id && !empty($inv['items']) && is_array($inv['items'])) {
+                $itemsHtml = '';
+                foreach ($inv['items'] as $it) {
+                    $itemsHtml .= '<tr>' .
+                        '<td>' . htmlspecialchars($it['orderNumber'] ?? '') . '</td>' .
+                        '<td>' . htmlspecialchars($it['trackingCode'] ?? '') . '</td>' .
+                        '<td>' . htmlspecialchars($it['shippingProof'] ?? '') . '</td>' .
+                        '<td>' . htmlspecialchars($it['customerName'] ?? '') . '</td>' .
+                        '<td>' . htmlspecialchars($it['address'] ?? '') . '</td>' .
+                        '<td>' . htmlspecialchars($it['countryName'] ?? '') . '</td>' .
+                        '<td>' . htmlspecialchars($it['productName'] ?? '') . '</td>' .
+                        '<td>' . htmlspecialchars($it['stripe'] ?? '') . '</td>' .
+                        '<td class="amount">' . htmlspecialchars($it['productCost'] ?? '') . '</td>' .
+                        '<td class="amount">' . htmlspecialchars($it['shippingCost'] ?? '') . '</td>' .
+                        '<td class="amount">' . htmlspecialchars($it['totalCost'] ?? '') . '</td>' .
+                        '<td>' . htmlspecialchars($it['note'] ?? '') . '</td>' .
+                        '</tr>';
+                }
+
+                $html = <<<HTML
+<html>
+<head>
+<style>
+body{font-family: DejaVu Sans, sans-serif; font-size:12px; color:#333;}
+table{width:100%; border-collapse:collapse;}
+th,td{border:1px solid #ccc; padding:4px;}
+th{background:#f0f0f0;}
+.amount{text-align:right;}
+</style>
+</head>
+<body>
+<h2>Invoice #$id</h2>
+<table>
+<thead>
+<tr>
+  <th>Order Number</th>
+  <th>Tracking Code</th>
+  <th>Shipping Proof</th>
+  <th>Customer Name</th>
+  <th>Address</th>
+  <th>Country Name</th>
+  <th>Product Name</th>
+  <th>Stripe</th>
+  <th>Product Cost</th>
+  <th>Shipping Cost</th>
+  <th>Total Cost</th>
+  <th>Note</th>
+</tr>
+</thead>
+<tbody>
+$itemsHtml
+</tbody>
+</table>
+</body>
+</html>
+HTML;
+
+                output_pdf($html, $localFile, $id);
+                exit;
+            }
+        }
+    }
 }
 
 // --- Fetch order details from WooCommerce ---
@@ -121,20 +208,6 @@ th { background: #f0f0f0; }
 HTML;
 
 // --- Generate PDF using TCPDF ---
-$pdf = new TCPDF();
-$pdf->SetCreator('Delivery Portal');
-$pdf->SetAuthor('Delivery Portal');
-$pdf->SetTitle('Invoice #' . $id);
-$pdf->SetMargins(15, 15, 15);
-$pdf->AddPage();
-$pdf->writeHTML($html, true, false, true, false, '');
-
-$pdf->Output($localFile, 'F');
-$pdfContent = file_get_contents($localFile);
-
-header('Content-Type: application/pdf');
-header('Content-Disposition: attachment; filename="invoice-' . $id . '.pdf"');
-header('Content-Length: ' . strlen($pdfContent));
-echo $pdfContent;
+output_pdf($html, $localFile, $id);
 exit;
 ?>


### PR DESCRIPTION
## Summary
- check `invoices.json` when invoice PDF isn't found
- render invoice PDF using stored items so the layout matches the View Invoice modal
- fall back to WooCommerce order data if the invoice isn't in JSON

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68408c253628832f8070165365ad82b0