### PR TITLE
Improve invoice error handling

### DIFF
--- a/assets/cPhp/download_invoice.php
+++ b/assets/cPhp/download_invoice.php
@@ -5,7 +5,13 @@
 
 require_once __DIR__ . '/master-api.php';
 // Use TCPDF for generating PDFs from HTML templates
-require_once '/usr/share/php/tcpdf/tcpdf.php';
+if (file_exists('/usr/share/php/tcpdf/tcpdf.php')) {
+    require_once '/usr/share/php/tcpdf/tcpdf.php';
+} else {
+    http_response_code(500);
+    echo 'TCPDF library not found at /usr/share/php/tcpdf/tcpdf.php';
+    exit;
+}
 
 $id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 if (!$id) {

--- a/assets/cPhp/master-api.php
+++ b/assets/cPhp/master-api.php
@@ -35,6 +35,8 @@ $consumer_secret = getenv('WOOCOMMERCE_CS');
 $store_url       = getenv('STORE_URL');
 
 if (!$consumer_key || !$consumer_secret || !$store_url) {
-    die('Environment variables WOOCOMMERCE_CK, WOOCOMMERCE_CS and STORE_URL must be set.');
+    http_response_code(500);
+    echo 'Required environment variables WOOCOMMERCE_CK, WOOCOMMERCE_CS and STORE_URL are not set.';
+    exit;
 }
 ?>

--- a/assets/js/cJs/invoices.js
+++ b/assets/js/cJs/invoices.js
@@ -64,8 +64,11 @@ $(document).on('click', '.invoice-download', function(e) {
   const url = $(this).attr('href');
   const id  = $(this).data('id');
   fetch(url)
-    .then(r => {
-      if (!r.ok) throw new Error('Invoice not found');
+    .then(async r => {
+      if (!r.ok) {
+        const msg = await r.text();
+        throw new Error(msg || 'Failed to download invoice');
+      }
       return r.blob();
     })
     .then(blob => {


### PR DESCRIPTION
## Summary
- return HTTP 500 from `master-api.php` when required env vars are missing
- gracefully handle missing TCPDF in `download_invoice.php`
- surface server error text in invoice downloads

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68408c25d650832f915fdfc7eb9843b2