### PR TITLE
Fix congested tables with scrolling

### DIFF
--- a/cancelled-orders.php
+++ b/cancelled-orders.php
@@ -15,7 +15,7 @@
     <!-- Inline CSS -->
     <style>
       td {
-        white-space: normal;
+        white-space: nowrap;
         vertical-align: top;
       }
       .items-col p {

--- a/factory-documents.php
+++ b/factory-documents.php
@@ -30,10 +30,12 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
             <div class="col-md-4"><input type="file" name="document" class="form-control" required></div>
             <div class="col-md-2"><button class="btn btn-primary w-100">Upload</button></div>
           </form>
-          <table class="table table-bordered">
-            <thead><tr><th>ID</th><th>Supplier</th><th>Product</th><th>File</th><th>Uploaded</th></tr></thead>
-            <tbody id="docsBody"></tbody>
-          </table>
+          <div class="table-responsive">
+            <table class="table table-bordered">
+              <thead><tr><th>ID</th><th>Supplier</th><th>Product</th><th>File</th><th>Uploaded</th></tr></thead>
+              <tbody id="docsBody"></tbody>
+            </table>
+          </div>
         </div>
       </section>
       <footer class="footer"><script src="assets/js/cJs/footer.js"></script></footer>

--- a/in-transit-orders.php
+++ b/in-transit-orders.php
@@ -15,7 +15,7 @@
     <!-- Inline CSS -->
     <style>
       td {
-        white-space: normal;
+        white-space: nowrap;
         vertical-align: top;
       }
       .items-col p {

--- a/inventory-management.php
+++ b/inventory-management.php
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="assets/css/main.css"/>
 
     <style>
-      td { white-space: normal; vertical-align: top; }
+      td { white-space: nowrap; vertical-align: top; }
       .badge { font-size: .9em; }
     </style>
   </head>

--- a/lead-times.php
+++ b/lead-times.php
@@ -30,10 +30,12 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
             <div class="col-md-3"><input id="lt_time" class="form-control" placeholder="Lead Time (days)" required></div>
             <div class="col-md-3"><button class="btn btn-primary w-100">Save</button></div>
           </form>
-          <table class="table table-bordered">
-            <thead><tr><th>ID</th><th>Product</th><th>Supplier</th><th>Lead Time</th><th>Updated</th></tr></thead>
-            <tbody id="timesBody"></tbody>
-          </table>
+          <div class="table-responsive">
+            <table class="table table-bordered">
+              <thead><tr><th>ID</th><th>Product</th><th>Supplier</th><th>Lead Time</th><th>Updated</th></tr></thead>
+              <tbody id="timesBody"></tbody>
+            </table>
+          </div>
         </div>
       </section>
       <footer class="footer"><script src="assets/js/cJs/footer.js"></script></footer>

--- a/new-orders.php
+++ b/new-orders.php
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="assets/css/main.css"/>
 
     <style>
-      td { white-space: normal; vertical-align: top; }
+      td { white-space: nowrap; vertical-align: top; }
       .items-col p { margin: 0; }
       /* green dropdown for New Orders */
       .card-style .dropdown-toggle {

--- a/new-product-requests.php
+++ b/new-product-requests.php
@@ -35,10 +35,12 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
             <div class="col-md-4"><input id="description" class="form-control" placeholder="Description"></div>
             <div class="col-md-2"><button class="btn btn-primary w-100">Add</button></div>
           </form>
-          <table class="table table-bordered">
-            <thead><tr><th>ID</th><th>Supplier</th><th>Product</th><th>Description</th><th>Requested</th></tr></thead>
-            <tbody id="requestsBody"></tbody>
-          </table>
+          <div class="table-responsive">
+            <table class="table table-bordered">
+              <thead><tr><th>ID</th><th>Supplier</th><th>Product</th><th>Description</th><th>Requested</th></tr></thead>
+              <tbody id="requestsBody"></tbody>
+            </table>
+          </div>
         </div>
       </section>
       <footer class="footer">

--- a/on-hold-orders.php
+++ b/on-hold-orders.php
@@ -15,7 +15,7 @@
     <!-- Inline CSS -->
     <style>
       td {
-        white-space: normal;
+        white-space: nowrap;
         vertical-align: top;
       }
       .items-col p {

--- a/pending-orders.php
+++ b/pending-orders.php
@@ -15,7 +15,7 @@
     <!-- Inline CSS -->
     <style>
       td {
-        white-space: normal;
+        white-space: nowrap;
         vertical-align: top;
       }
       .items-col p {

--- a/product-management.php
+++ b/product-management.php
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="assets/css/main.css"/>
 
     <style>
-      td { white-space: normal; vertical-align: top; }
+      td { white-space: nowrap; vertical-align: top; }
       img { border-radius: 4px; }
       .badge { font-size: .9em; }
     </style>

--- a/refunded-orders.php
+++ b/refunded-orders.php
@@ -15,7 +15,7 @@
     <!-- Inline CSS -->
     <style>
       td {
-        white-space: normal;
+        white-space: nowrap;
         vertical-align: top;
       }
       .items-col p {

--- a/returned-orders.php
+++ b/returned-orders.php
@@ -15,7 +15,7 @@
     <!-- Inline CSS -->
     <style>
       td {
-        white-space: normal;
+        white-space: nowrap;
         vertical-align: top;
       }
       .items-col p {

--- a/supplier-pricing.php
+++ b/supplier-pricing.php
@@ -32,10 +32,12 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
             <div class="col-md-2"><input id="sp_date" type="date" class="form-control"></div>
             <div class="col-md-2"><button class="btn btn-primary w-100">Save</button></div>
           </form>
-          <table class="table table-bordered">
-            <thead><tr><th>ID</th><th>Supplier</th><th>Product</th><th>Price</th><th>Bulk Price</th><th>Effective</th></tr></thead>
-            <tbody id="pricesBody"></tbody>
-          </table>
+          <div class="table-responsive">
+            <table class="table table-bordered">
+              <thead><tr><th>ID</th><th>Supplier</th><th>Product</th><th>Price</th><th>Bulk Price</th><th>Effective</th></tr></thead>
+              <tbody id="pricesBody"></tbody>
+            </table>
+          </div>
         </div>
       </section>
       <footer class="footer"><script src="assets/js/cJs/footer.js"></script></footer>


### PR DESCRIPTION
## Summary
- wrap unresponsive tables in `.table-responsive`
- prevent table cell wrapping so tables scroll horizontally

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ab1799f0832f970df7196b030960