### PR TITLE
Improve table layout and variant display

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5985,4 +5985,14 @@ h6,
   }
 }
 
+/* Ensure tables can scroll horizontally at all breakpoints */
+.table-responsive {
+  overflow-x: auto;
+}
+
+/* Display semicolon-separated variant data on separate lines */
+td.variant-info {
+  white-space: pre-line;
+}
+
 /*# sourceMappingURL=main.css.map */

--- a/assets/js/cJs/product-management.js
+++ b/assets/js/cJs/product-management.js
@@ -77,7 +77,7 @@ function renderTable() {
 
   filtered.forEach(p => {
     const variants = Array.isArray(p.variant_attributes)
-      ? p.variant_attributes.map(v => v.map(a => `${a.name}: ${a.option}`).join(' / ')).join('; ')
+      ? p.variant_attributes.map(v => v.map(a => `${a.name}: ${a.option}`).join(' / ')).join('\n')
       : '';
     $tb.append(`
       <tr>
@@ -85,7 +85,7 @@ function renderTable() {
         <td><img src="${escapeHtml(p.images?.[0]?.src || '')}" width="50"/></td>
         <td>${escapeHtml(p.name)}</td>
         <td>${escapeHtml(p.sku || '')}</td>
-        <td>${escapeHtml(variants)}</td>
+        <td class="variant-info">${escapeHtml(variants)}</td>
         <td>${escapeHtml(p.stock_quantity ?? 'N/A')}</td>
         <td>${escapeHtml(p.price)}</td>
         <td>${escapeHtml(p.moq ?? '')}</td>


### PR DESCRIPTION
## Summary
- allow tables to scroll on all screen sizes
- show variant info on separate lines

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840ae3cbb80832f8b4c2b4e08e9a94a