### PR TITLE
Add analytics and settings tests

### DIFF
--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -1,0 +1,23 @@
+describe('dynamic-pie-chart.js', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div class="pie-chart" data-percentage="75" data-diameter="80"></div>';
+    HTMLCanvasElement.prototype.getContext = () => ({
+      beginPath: jest.fn(),
+      arc: jest.fn(),
+      stroke: jest.fn()
+    });
+    delete require.cache[require.resolve('../assets/js/dynamic-pie-chart.js')];
+    require('../assets/js/dynamic-pie-chart.js');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('creates canvas elements', () => {
+    const canvas = document.querySelector('.pie-chart canvas');
+    expect(canvas).not.toBeNull();
+    const span = document.querySelector('.pie-chart__percentage');
+    expect(span).not.toBeNull();
+  });
+});

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+
+describe('payment_terms.js', () => {
+  let script;
+  beforeAll(() => {
+    script = fs.readFileSync(path.resolve(__dirname, '../assets/js/cJs/payment_terms.js'), 'utf8');
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = '<table id="termsTable"><tbody></tbody></table><div id="termModal"></div><input id="termId"/><input id="termName"/><textarea id="termDesc"></textarea>';
+    delete require.cache[require.resolve('jquery')];
+    global.$ = require('jquery');
+    $.fn.modal = jest.fn();
+    global.BASE_URL = '';
+    $.getJSON = jest.fn();
+    $.ajax = jest.fn();
+    vm.runInNewContext(script, global);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    delete global.$;
+    delete global.loadTerms;
+    delete global.saveTerm;
+  });
+
+  test('loadTerms populates table rows', () => {
+    $.getJSON.mockImplementation((url, cb) => cb([{id:1,name:'Net 30',description:'Pay in 30 days'}]));
+    loadTerms();
+    const rows = document.querySelectorAll('#termsTable tbody tr');
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('Net 30');
+  });
+
+  test('saveTerm posts data and reloads', () => {
+    const spyLoad = jest.spyOn(global, 'loadTerms');
+    $.ajax.mockImplementation(opts => { if (opts.success) opts.success(); });
+    $('#termId').val('2');
+    $('#termName').val('Advance');
+    $('#termDesc').val('Pay upfront');
+    saveTerm();
+    expect($.ajax).toHaveBeenCalled();
+    const arg = $.ajax.mock.calls[0][0];
+    expect(JSON.parse(arg.data)).toEqual({id:'2',name:'Advance',description:'Pay upfront'});
+    expect($.fn.modal).toHaveBeenCalledWith('hide');
+    expect(spyLoad).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `analytics.test.js` to test pie chart rendering
- add `settings.test.js` to test payment term settings AJAX

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458cfb3908832f9be89bd24cdd6f8a