### PR TITLE
Add analytics page and charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,9 @@ PDF with:
 ```bash
 php assets/cPhp/download_invoice.php?id=1 > invoice-1.pdf
 ```
+
+## Analytics
+
+Visit `analytics.php` to view weekly and monthly sales graphs. The page pulls
+data from `assets/cPhp/get_dashboard_summary.php` and renders charts with
+Chart.js.

--- a/analytics.php
+++ b/analytics.php
@@ -1,0 +1,58 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/server-config.php';
+$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
+?>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="shortcut icon" href="assets/images/favicon.svg" type="image/x-icon" />
+    <title>Sales Analytics</title>
+    <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="assets/css/lineicons.css" />
+    <link rel="stylesheet" href="assets/css/materialdesignicons.min.css" />
+    <link rel="stylesheet" href="assets/css/main.css" />
+  </head>
+  <body>
+    <div id="skeleton-loader"><div class="skeleton-block"></div></div>
+    <aside class="sidebar-nav-wrapper">
+      <script src="assets/js/cJs/sidebar.js"></script>
+    </aside>
+    <div class="overlay"></div>
+    <main class="main-wrapper">
+      <header class="header">
+        <script src="assets/js/cJs/header.js"></script>
+        <script src="assets/js/cJs/menuToggle.js"></script>
+      </header>
+      <section class="section">
+        <div class="container-fluid">
+          <div class="title-wrapper pt-30 mb-3">
+            <h2 class="page-title">Sales Analytics</h2>
+          </div>
+          <div class="row">
+            <div class="col-lg-6">
+              <div class="card-style mb-30">
+                <h6 class="text-medium mb-25">Last 7 Days</h6>
+                <canvas id="chartWeek" height="200"></canvas>
+              </div>
+            </div>
+            <div class="col-lg-6">
+              <div class="card-style mb-30">
+                <h6 class="text-medium mb-25">Last 12 Months</h6>
+                <canvas id="chartMonth" height="200"></canvas>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <footer class="footer"><script src="assets/js/cJs/footer.js"></script></footer>
+    </main>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="assets/js/bootstrap.bundle.min.js"></script>
+    <script src="assets/js/Chart.min.js"></script>
+    <script src="assets/js/main.js"></script>
+    <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+    <script src="assets/js/cJs/analytics.js"></script>
+  </body>
+</html>

--- a/assets/js/cJs/analytics.js
+++ b/assets/js/cJs/analytics.js
@@ -1,0 +1,58 @@
+// assets/js/cJs/analytics.js
+
+$(function(){
+  $.getJSON(`${BASE_URL}/assets/cPhp/get_dashboard_summary.php`, data => {
+    const week = data.chart_data || {labels:[], revenue:[], profit:[], orders:[]};
+    const month = data.chart1 || {labels:[], revenue:[]};
+
+    const ctxWeek = document.getElementById('chartWeek');
+    if (ctxWeek) {
+      new Chart(ctxWeek, {
+        type: 'line',
+        data: {
+          labels: week.labels,
+          datasets: [
+            {
+              label: 'Revenue',
+              data: week.revenue,
+              borderColor: '#4F46E5',
+              backgroundColor: 'rgba(99,102,241,0.3)',
+              tension: 0.3,
+            },
+            {
+              label: 'Profit',
+              data: week.profit,
+              borderColor: '#059669',
+              backgroundColor: 'rgba(16,185,129,0.3)',
+              tension: 0.3,
+            },
+            {
+              label: 'Orders',
+              data: week.orders,
+              borderColor: '#F59E0B',
+              backgroundColor: 'rgba(245,158,11,0.3)',
+              tension: 0.3,
+            }
+          ]
+        },
+        options: { responsive: true, maintainAspectRatio: false }
+      });
+    }
+
+    const ctxMonth = document.getElementById('chartMonth');
+    if (ctxMonth) {
+      new Chart(ctxMonth, {
+        type: 'bar',
+        data: {
+          labels: month.labels,
+          datasets: [{
+            label: 'Revenue',
+            data: month.revenue,
+            backgroundColor: '#4F46E5'
+          }]
+        },
+        options: { responsive: true, maintainAspectRatio: false }
+      });
+    }
+  });
+});

--- a/assets/js/cJs/sidebar.js
+++ b/assets/js/cJs/sidebar.js
@@ -16,6 +16,12 @@ const sidebarHTML = `
           <span class="text">Dashboard</span>
         </a>
       </li>
+      <li class="nav-item">
+        <a href="analytics.php">
+          <span class="icon"><i class="lni lni-bar-chart"></i></span>
+          <span class="text">Analytics</span>
+        </a>
+      </li>
       <!-- Orders -->
       <li class="nav-item nav-item-has-children">
         <a href="#0" class="collapsed" data-bs-toggle="collapse" data-bs-target="#ddmenu_orders" aria-controls="ddmenu_orders" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
## Summary
- create `analytics.php` for weekly & monthly sales charts
- implement sidebar link for new Analytics page
- render charts in `assets/js/cJs/analytics.js`
- document analytics page in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458cf7b240832f95e959b6735f0a77