### PR TITLE
Switch product request status updates to SQLite

### DIFF
--- a/assets/cPhp/update_product_request.php
+++ b/assets/cPhp/update_product_request.php
@@ -1,25 +1,35 @@
 <?php
 // assets/cPhp/update_product_request.php
+// Update the status of a product request in the SQLite database
+
+require_once __DIR__ . '/db.php';
+
 header('Content-Type: application/json; charset=utf-8');
-$file = __DIR__ . '/../data/product_requests.json';
-$data = file_exists($file) ? json_decode(file_get_contents($file), true) : [];
-$raw = file_get_contents('php://input');
+
+// Gather JSON or form payload
+$raw     = file_get_contents('php://input');
 $payload = json_decode($raw, true) ?: $_POST;
-$id = isset($payload['id']) ? (int)$payload['id'] : 0;
-$status = isset($payload['status']) ? $payload['status'] : '';
-if(!$id || !in_array($status,['Approved','Rejected'])){
+
+$id     = isset($payload['id']) ? (int)$payload['id'] : 0;
+$status = $payload['status'] ?? '';
+
+if (!$id || !in_array($status, ['Approved', 'Rejected'], true)) {
     http_response_code(400);
-    echo json_encode(['error'=>'Invalid request']);
+    echo json_encode(['error' => 'Invalid request']);
     exit;
 }
-foreach($data as &$req){
-    if($req['id']==$id){
-        $req['status'] = $status;
-        break;
-    }
+
+// Update the row and report success only if a record was affected
+$stmt = $db->prepare('UPDATE product_requests SET status = :status WHERE id = :id');
+$stmt->bindValue(':status', $status, SQLITE3_TEXT);
+$stmt->bindValue(':id', $id, SQLITE3_INTEGER);
+$result = $stmt->execute();
+
+if ($db->changes() === 0) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Request not found']);
+    exit;
 }
-unset($req);
-file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT));
-echo json_encode(['success'=>true]);
-exit;
+
+echo json_encode(['success' => true]);
 ?>


### PR DESCRIPTION
## Summary
- update `update_product_request.php` to modify the `product_requests` table instead of a JSON file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684595dfc4d8832f85ef6664d07d1262