### PR TITLE
Fix logistic orders page

### DIFF
--- a/assets/js/cJs/logistics_orders.js
+++ b/assets/js/cJs/logistics_orders.js
@@ -27,7 +27,7 @@ function fetchLogisticsOrders(page=1){
   const params = { page, per_page: PER_PAGE };
   if (searchOrderId) params.order_id = searchOrderId;
   $.ajax({
-    url: 'assets/cPhp/get_shipments_summary.php',
+    url: `${BASE_URL}/assets/cPhp/get_shipments_summary.php`,
     method: 'GET',
     data: params,
     dataType: 'json',

--- a/assets/js/cJs/sidebar.js
+++ b/assets/js/cJs/sidebar.js
@@ -73,7 +73,7 @@ const sidebarHTML = `
         </a>
         <ul id="ddmenu_logistics" class="collapse dropdown-nav" data-bs-parent="#sidebar-menu">
           <li><a href="shipments.php">Shipments</a></li>
-          <li><a href="logistics-orders.html">Logistics Orders</a></li>
+          <li><a href="logistics-orders.php">Logistics Orders</a></li>
         </ul>
       </li>
 

--- a/logistics-orders.php
+++ b/logistics-orders.php
@@ -1,3 +1,7 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/server-config.php';
+$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
+?>
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -28,6 +32,7 @@
       .status-processing { background-color: #d1ecf1; color: #0c5460; }
       /* ... Add more .status-* classes as needed ... */
     </style>
+  <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
   </head>
   <body>
     <!-- ======== Preloader (optional) =========== -->


### PR DESCRIPTION
## Summary
- convert `logistics-orders.html` to PHP so the portal base URL is available
- fetch shipments from the correct API endpoint in `logistics_orders.js`
- update sidebar link to point at `logistics-orders.php`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684595e0479c832fa72b566f1d0cc08e