### PR TITLE
Add analytics charts

### DIFF
--- a/assets/js/cJs/analytics.js
+++ b/assets/js/cJs/analytics.js
@@ -43,5 +43,56 @@ $(function() {
         $b.append(`<tr><td>${name}</td><td>${values[i].toFixed(2)}%</td></tr>`);
       });
     }
+
+    if (data.chart_data && document.getElementById('chartWeek')) {
+      new Chart(document.getElementById('chartWeek'), {
+        type: 'line',
+        data: {
+          labels: data.chart_data.labels,
+          datasets: [
+            {
+              label: 'Revenue',
+              data: data.chart_data.revenue,
+              borderColor: '#4caf50',
+              backgroundColor: 'rgba(76, 175, 80, 0.2)',
+              yAxisID: 'y'
+            },
+            {
+              label: 'Orders',
+              data: data.chart_data.orders,
+              borderColor: '#2196f3',
+              backgroundColor: 'rgba(33, 150, 243, 0.2)',
+              yAxisID: 'y1'
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          scales: {
+            y: { beginAtZero: true, position: 'left' },
+            y1: {
+              beginAtZero: true,
+              position: 'right',
+              grid: { drawOnChartArea: false }
+            }
+          }
+        }
+      });
+    }
+
+    if (data.chart1 && document.getElementById('chartMonth')) {
+      new Chart(document.getElementById('chartMonth'), {
+        type: 'bar',
+        data: {
+          labels: data.chart1.labels,
+          datasets: [{
+            label: 'Revenue',
+            data: data.chart1.revenue,
+            backgroundColor: '#42a5f5'
+          }]
+        },
+        options: { responsive: true }
+      });
+    }
   });
 });

--- a/tests/analytics_charts.test.js
+++ b/tests/analytics_charts.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+describe('analytics.js charts', () => {
+  const scriptPath = path.resolve(__dirname, '../assets/js/cJs/analytics.js');
+  test('creates weekly and monthly charts', () => {
+    const dom = new JSDOM('<!doctype html><html><body><canvas id="chartWeek"></canvas><canvas id="chartMonth"></canvas></body></html>');
+    const context = dom.window;
+    context.BASE_URL = '';
+    const $ = fn => { if (typeof fn === 'function') fn(); return { length:0, text:()=>{}, append:()=>{}, empty:()=>{} }; };
+    $.getJSON = jest.fn((url, cb) => cb({
+      chart_data: { labels: ['A','B'], revenue: [1,2], orders: [3,4] },
+      chart1: { labels: ['Jan','Feb'], revenue: [5,6] }
+    }));
+    context.$ = context.jQuery = $;
+    context.Chart = jest.fn();
+    Object.defineProperty(context.document, 'readyState', { configurable: true, value: 'complete' });
+    const fn = new Function('window','document','$','Chart','BASE_URL', fs.readFileSync(scriptPath,'utf8'));
+    fn(context, context.document, context.$, context.Chart, context.BASE_URL);
+    expect(context.Chart).toHaveBeenCalledTimes(2);
+    const weekCfg = context.Chart.mock.calls[0][1];
+    expect(weekCfg.data.labels).toEqual(['A','B']);
+    expect(weekCfg.data.datasets[0].data).toEqual([1,2]);
+    expect(weekCfg.data.datasets[1].data).toEqual([3,4]);
+    const monthCfg = context.Chart.mock.calls[1][1];
+    expect(monthCfg.data.labels).toEqual(['Jan','Feb']);
+    expect(monthCfg.data.datasets[0].data).toEqual([5,6]);
+  });
+});


### PR DESCRIPTION
## Summary
- fetch new chart data in `analytics.js`
- render revenue and order charts for week and month views
- test that charts are created using data from `get_dashboard_summary.php`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684595e0c6c8832f9c8c291048c4d70f