### PR TITLE
Implement multiple portal enhancements

### DIFF
--- a/assets/cPhp/add_refund_comment.php
+++ b/assets/cPhp/add_refund_comment.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/db.php';
+header('Content-Type: application/json; charset=utf-8');
+$raw = file_get_contents('php://input');
+if ($raw === '' && PHP_SAPI === 'cli') {
+    $raw = stream_get_contents(STDIN);
+}
+$data = json_decode($raw, true) ?: $_POST;
+$refund = isset($data['refund_id']) ? (int)$data['refund_id'] : 0;
+$user   = isset($data['user_id']) ? (int)$data['user_id'] : 0;
+$comment= trim($data['comment'] ?? '');
+if (!$refund || !$user || $comment==='') {
+    http_response_code(400);
+    echo json_encode(['error'=>'Invalid payload']);
+    exit;
+}
+$stmt = $db->prepare('INSERT INTO refund_comments (refund_id,user_id,comment) VALUES (:r,:u,:c)');
+$stmt->bindValue(':r', $refund, SQLITE3_INTEGER);
+$stmt->bindValue(':u', $user, SQLITE3_INTEGER);
+$stmt->bindValue(':c', $comment, SQLITE3_TEXT);
+$stmt->execute();
+ echo json_encode(['success'=>true,'id'=>$db->lastInsertRowID()]);
+?>

--- a/assets/cPhp/db.php
+++ b/assets/cPhp/db.php
@@ -1,8 +1,8 @@
 <?php
 // portal/assets/cPhp/db.php
 
-// Path to SQLite database file
-$dbFile = __DIR__ . '/../../data.sqlite';
+// Path to SQLite database file - allow override via DB_FILE env var
+$dbFile = getenv('DB_FILE') ?: (__DIR__ . '/../../data.sqlite');
 
 // Open connection
 $db = new SQLite3($dbFile);
@@ -41,5 +41,35 @@ $db->exec('CREATE TABLE IF NOT EXISTS factory_documents (
     product TEXT,
     file_path TEXT,
     uploaded_at TEXT DEFAULT CURRENT_TIMESTAMP
+)');
+
+$db->exec('CREATE TABLE IF NOT EXISTS price_tiers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id INTEGER,
+    min_qty INTEGER,
+    max_qty INTEGER,
+    unit_price REAL
+)');
+
+$db->exec('CREATE TABLE IF NOT EXISTS inventory_settings (
+    product_id INTEGER PRIMARY KEY,
+    safety_stock INTEGER,
+    reorder_threshold INTEGER
+)');
+
+$db->exec('CREATE TABLE IF NOT EXISTS stock_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id INTEGER,
+    change_qty INTEGER,
+    reason TEXT,
+    timestamp TEXT DEFAULT CURRENT_TIMESTAMP
+)');
+
+$db->exec('CREATE TABLE IF NOT EXISTS refund_comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    refund_id INTEGER,
+    user_id INTEGER,
+    comment TEXT,
+    timestamp TEXT DEFAULT CURRENT_TIMESTAMP
 )');
 ?>

--- a/assets/cPhp/get_bulk_pricing.php
+++ b/assets/cPhp/get_bulk_pricing.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/db.php';
+header('Content-Type: application/json; charset=utf-8');
+$productId = isset($_GET['product_id']) ? (int)$_GET['product_id'] : 0;
+if ($productId) {
+    $stmt = $db->prepare('SELECT * FROM price_tiers WHERE product_id = :pid ORDER BY min_qty');
+    $stmt->bindValue(':pid', $productId, SQLITE3_INTEGER);
+    $res = $stmt->execute();
+} else {
+    $res = $db->query('SELECT * FROM price_tiers ORDER BY product_id, min_qty');
+}
+$rows = [];
+while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+    $rows[] = $row;
+}
+ echo json_encode($rows);
+?>

--- a/assets/cPhp/get_refund_comments.php
+++ b/assets/cPhp/get_refund_comments.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/db.php';
+header('Content-Type: application/json; charset=utf-8');
+$id = isset($_GET['refund_id']) ? (int)$_GET['refund_id'] : 0;
+if (!$id) { echo json_encode([]); exit; }
+$stmt = $db->prepare('SELECT user_id, comment, timestamp FROM refund_comments WHERE refund_id = :r ORDER BY timestamp ASC');
+$stmt->bindValue(':r', $id, SQLITE3_INTEGER);
+$res = $stmt->execute();
+$rows = [];
+while ($row = $res->fetchArray(SQLITE3_ASSOC)) { $rows[] = $row; }
+ echo json_encode($rows);
+?>

--- a/assets/cPhp/get_stock_log.php
+++ b/assets/cPhp/get_stock_log.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/db.php';
+header('Content-Type: application/json; charset=utf-8');
+$id = isset($_GET['product_id']) ? (int)$_GET['product_id'] : 0;
+if (!$id) { echo json_encode([]); exit; }
+$stmt = $db->prepare('SELECT change_qty, reason, timestamp FROM stock_log WHERE product_id = :p ORDER BY timestamp DESC');
+$stmt->bindValue(':p', $id, SQLITE3_INTEGER);
+$res = $stmt->execute();
+$rows = [];
+while ($row = $res->fetchArray(SQLITE3_ASSOC)) { $rows[] = $row; }
+ echo json_encode($rows);
+?>

--- a/assets/cPhp/update_bulk_pricing.php
+++ b/assets/cPhp/update_bulk_pricing.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/db.php';
+header('Content-Type: application/json; charset=utf-8');
+$raw = file_get_contents('php://input');
+if ($raw === '' && PHP_SAPI === 'cli') {
+    $raw = stream_get_contents(STDIN);
+}
+$data = json_decode($raw, true) ?: $_POST;
+$productId = isset($data['product_id']) ? (int)$data['product_id'] : 0;
+$tiers = $data['tiers'] ?? null;
+if (!$productId || !is_array($tiers)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid payload']);
+    exit;
+}
+$db->exec('BEGIN');
+$stmtDel = $db->prepare('DELETE FROM price_tiers WHERE product_id = :pid');
+$stmtDel->bindValue(':pid', $productId, SQLITE3_INTEGER);
+$stmtDel->execute();
+$insert = $db->prepare('INSERT INTO price_tiers (product_id,min_qty,max_qty,unit_price) VALUES (:pid,:min,:max,:price)');
+foreach ($tiers as $t) {
+    $insert->bindValue(':pid', $productId, SQLITE3_INTEGER);
+    $insert->bindValue(':min', intval($t['min_qty'] ?? 0), SQLITE3_INTEGER);
+    $insert->bindValue(':max', intval($t['max_qty'] ?? 0), SQLITE3_INTEGER);
+    $insert->bindValue(':price', floatval($t['unit_price'] ?? 0), SQLITE3_FLOAT);
+    $insert->execute();
+}
+$db->exec('COMMIT');
+echo json_encode(['success' => true]);
+?>

--- a/assets/cPhp/update_inventory_settings.php
+++ b/assets/cPhp/update_inventory_settings.php
@@ -1,0 +1,24 @@
+<?php
+require_once __DIR__ . '/db.php';
+header('Content-Type: application/json; charset=utf-8');
+$raw = file_get_contents('php://input');
+if ($raw === '' && PHP_SAPI === 'cli') {
+    $raw = stream_get_contents(STDIN);
+}
+$data = json_decode($raw, true) ?: $_POST;
+$product = isset($data['product_id']) ? (int)$data['product_id'] : 0;
+$safety = isset($data['safety_stock']) ? (int)$data['safety_stock'] : null;
+$reorder = isset($data['reorder_threshold']) ? (int)$data['reorder_threshold'] : null;
+if (!$product) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing product_id']);
+    exit;
+}
+$stmt = $db->prepare('REPLACE INTO inventory_settings (product_id,safety_stock,reorder_threshold) VALUES (:p,:s,:r)');
+$stmt->bindValue(':p', $product, SQLITE3_INTEGER);
+$stmt->bindValue(':s', $safety, SQLITE3_INTEGER);
+$stmt->bindValue(':r', $reorder, SQLITE3_INTEGER);
+$stmt->execute();
+
+echo json_encode(['success' => true]);
+?>

--- a/assets/cPhp/update_refund_status.php
+++ b/assets/cPhp/update_refund_status.php
@@ -1,0 +1,41 @@
+<?php
+require_once __DIR__ . '/master-api.php';
+header('Content-Type: application/json; charset=utf-8');
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input) || empty($input)) {
+    $input = $_POST;
+}
+
+$refund_id = isset($input['refund_id']) ? (int)$input['refund_id'] : 0;
+$status    = $input['status'] ?? '';
+if (!$refund_id || $status==='') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing refund_id or status']);
+    exit;
+}
+
+$endpoint = "/wp-json/wc/v3/refunds/{$refund_id}";
+$data = ['status' => $status];
+
+$ch = curl_init(rtrim($store_url,'/').$endpoint);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_USERPWD, "$consumer_key:$consumer_secret");
+curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+$resp = curl_exec($ch);
+$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+// handle file upload
+if (!empty($_FILES['proof']['tmp_name'])) {
+    $dir = __DIR__ . '/../uploads/refunds';
+    if (!is_dir($dir)) mkdir($dir, 0777, true);
+    $name = basename($_FILES['proof']['name']);
+    move_uploaded_file($_FILES['proof']['tmp_name'], "$dir/$refund_id-$name");
+}
+
+http_response_code($code);
+echo $resp;
+?>

--- a/assets/cPhp/update_tracking.php
+++ b/assets/cPhp/update_tracking.php
@@ -7,6 +7,16 @@ require_once __DIR__ . '/master-api.php';
 
 $apiKey = getenv('TRACK17_APIKEY');
 if (!$apiKey) {
+    $settingsFile = __DIR__ . '/../data/settings.json';
+    if (is_readable($settingsFile)) {
+        $settings = json_decode(file_get_contents($settingsFile), true);
+        if (isset($settings['shipping_key']) && $settings['shipping_key'] !== '') {
+            $apiKey = $settings['shipping_key'];
+        }
+    }
+}
+
+if (!$apiKey) {
     http_response_code(500);
     echo json_encode(['error' => 'TRACK17_APIKEY not set']);
     exit;

--- a/assets/js/cJs/product_requests.js
+++ b/assets/js/cJs/product_requests.js
@@ -31,6 +31,7 @@ function fetchRequests(page=1){
           <td>${r.product}</td>
           <td>${r.description || ''}</td>
           <td>${r.requested_at}</td>
+          <td><button class="btn btn-sm btn-secondary pricing-btn" data-id="${r.id}">Pricing</button></td>
         </tr>`;
       });
       const tbody = $('#requestsTable tbody,#requestsBody');
@@ -68,6 +69,13 @@ $(document).on('click', '.reject-btn', function(){
   updateStatus(id,'Rejected');
 });
 
+$(document).on('click', '.pricing-btn', function(){
+  const id = $(this).data('id');
+  $('#priceProductId').val(id);
+  loadTiers(id);
+  $('#pricingModal').modal('show');
+});
+
 function updateStatus(id,status){
   $.ajax({
     url:`${BASE_URL}/assets/cPhp/update_product_request.php`,
@@ -80,3 +88,43 @@ function updateStatus(id,status){
 
 // expose fetcher for pagination
 window.fetchPendingOrders = fetchRequests;
+
+function loadTiers(id){
+  $.getJSON(`${BASE_URL}/assets/cPhp/get_bulk_pricing.php`, {product_id:id}, tiers => {
+    const tbody = $('#tiersTable tbody').empty();
+    tiers.forEach(t => addTierRow(t.min_qty, t.max_qty, t.unit_price));
+  });
+}
+
+function addTierRow(min='', max='', price=''){
+  $('#tiersTable tbody').append(`
+    <tr>
+      <td><input type="number" class="form-control form-control-sm min" value="${min}"></td>
+      <td><input type="number" class="form-control form-control-sm max" value="${max}"></td>
+      <td><input type="number" step="0.01" class="form-control form-control-sm price" value="${price}"></td>
+      <td><button type="button" class="btn btn-sm btn-danger remove-tier">&times;</button></td>
+    </tr>`);
+}
+
+$('#addTier').on('click', () => addTierRow());
+
+$(document).on('click','.remove-tier', function(){ $(this).closest('tr').remove(); });
+
+$('#saveTiers').on('click', function(){
+  const product_id = $('#priceProductId').val();
+  const tiers = [];
+  $('#tiersTable tbody tr').each(function(){
+    tiers.push({
+      min_qty: $(this).find('.min').val(),
+      max_qty: $(this).find('.max').val(),
+      unit_price: $(this).find('.price').val()
+    });
+  });
+  $.ajax({
+    url:`${BASE_URL}/assets/cPhp/update_bulk_pricing.php`,
+    method:'POST',
+    contentType:'application/json',
+    data: JSON.stringify({product_id, tiers})
+  }).done(()=>$('#pricingModal').modal('hide'))
+    .fail(xhr=>alert('Save failed: ' + (xhr.responseJSON?.error || xhr.statusText)));
+});

--- a/db/migrations/001_create_price_tiers.sql
+++ b/db/migrations/001_create_price_tiers.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS price_tiers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id INTEGER NOT NULL,
+    min_qty INTEGER NOT NULL,
+    max_qty INTEGER NOT NULL,
+    unit_price REAL NOT NULL
+);

--- a/db/migrations/002_create_inventory_tables.sql
+++ b/db/migrations/002_create_inventory_tables.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS inventory_settings (
+    product_id INTEGER PRIMARY KEY,
+    safety_stock INTEGER,
+    reorder_threshold INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS stock_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    product_id INTEGER,
+    change_qty INTEGER,
+    reason TEXT,
+    timestamp TEXT DEFAULT CURRENT_TIMESTAMP
+);

--- a/db/migrations/003_create_refund_comments.sql
+++ b/db/migrations/003_create_refund_comments.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS refund_comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    refund_id INTEGER,
+    user_id INTEGER,
+    comment TEXT,
+    timestamp TEXT DEFAULT CURRENT_TIMESTAMP
+);

--- a/inventory-management.php
+++ b/inventory-management.php
@@ -81,7 +81,10 @@
                       <th>ID</th>
                       <th>Name</th>
                       <th>Stock</th>
+                      <th>Safety Stock</th>
+                      <th>Reorder Threshold</th>
                       <th>Status</th>
+                      <th>Actions</th>
                     </tr>
                   </thead>
                   <tbody><!-- injected by JS --></tbody>
@@ -97,6 +100,50 @@
           </div>
         </div>
       </section>
+
+      <!-- Edit Thresholds Modal -->
+      <div class="modal fade" id="thresholdModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">Inventory Settings</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+              <input type="hidden" id="invProductId" />
+              <div class="mb-3">
+                <label class="form-label">Safety Stock</label>
+                <input type="number" class="form-control" id="safetyStock" />
+              </div>
+              <div class="mb-3">
+                <label class="form-label">Reorder Threshold</label>
+                <input type="number" class="form-control" id="reorderThreshold" />
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-primary" id="saveThresholds">Save</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- History Modal -->
+      <div class="modal fade" id="historyModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">Stock History</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+              <table class="table" id="historyTable">
+                <thead><tr><th>Qty</th><th>Reason</th><th>Time</th></tr></thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <footer class="footer">
         <script src="assets/js/cJs/footer.js"></script>

--- a/product-requests.php
+++ b/product-requests.php
@@ -45,6 +45,7 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
                   <th>Product</th>
                   <th>Description</th>
                   <th>Requested</th>
+                  <th>Actions</th>
                 </tr>
               </thead>
               <tbody id="requestsBody"></tbody>
@@ -83,8 +84,31 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
             <button type="button" class="btn btn-primary" id="saveRequest">Submit</button>
           </div>
         </div>
+    </div>
+  </div>
+    <!-- Pricing Modal -->
+    <div class="modal fade" id="pricingModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Bulk Pricing</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <input type="hidden" id="priceProductId" />
+            <table class="table" id="tiersTable">
+              <thead><tr><th>Min Qty</th><th>Max Qty</th><th>Unit Price</th><th></th></tr></thead>
+              <tbody></tbody>
+            </table>
+            <button id="addTier" type="button" class="btn btn-sm btn-secondary">Add Tier</button>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" id="saveTiers">Save</button>
+          </div>
+        </div>
       </div>
     </div>
+
     <footer class="footer">
       <script src="assets/js/cJs/footer.js"></script>
     </footer>

--- a/refund-dashboard.php
+++ b/refund-dashboard.php
@@ -48,6 +48,7 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
                   <th>Reason</th>
                   <th>Proof</th>
                   <th>Status History</th>
+                  <th>Actions</th>
                 </tr>
               </thead>
               <tbody></tbody>

--- a/tests/bulk_pricing.test.js
+++ b/tests/bulk_pricing.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const {execFileSync} = require('child_process');
+const os = require('os');
+
+test('bulk pricing endpoints roundtrip', () => {
+  const dbPath = path.join(os.tmpdir(), 'bulk_test.sqlite');
+  try { fs.unlinkSync(dbPath); } catch(e) {}
+  const env = {...process.env, DB_FILE: dbPath};
+
+  const payload = JSON.stringify({
+    product_id: 1,
+    tiers: [
+      {min_qty:1,max_qty:10,unit_price:9.99},
+      {min_qty:11,max_qty:20,unit_price:8.99}
+    ]
+  });
+
+  execFileSync('php', ['assets/cPhp/update_bulk_pricing.php'], {input: payload, env});
+
+  const script = `$_GET['product_id']=1; include '${path.resolve('assets/cPhp/get_bulk_pricing.php')}';`;
+  const out = execFileSync('php', ['-r', script], {env});
+  const rows = JSON.parse(out.toString());
+  expect(rows.length).toBe(2);
+  expect(rows[0].unit_price).toBe(9.99);
+});

--- a/tests/inventory.test.js
+++ b/tests/inventory.test.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+const {execFileSync} = require('child_process');
+const os = require('os');
+
+test('update_inventory_settings stores thresholds', () => {
+  const dbPath = path.join(os.tmpdir(), 'inv_test.sqlite');
+  try { fs.unlinkSync(dbPath); } catch(e) {}
+  const env = {...process.env, DB_FILE: dbPath};
+  const payload = JSON.stringify({product_id:5,safety_stock:10,reorder_threshold:3});
+  execFileSync('php', ['assets/cPhp/update_inventory_settings.php'], {input:payload, env});
+  const out = execFileSync('sqlite3', [dbPath, "SELECT safety_stock,reorder_threshold FROM inventory_settings WHERE product_id=5;"]);
+  expect(out.toString().trim()).toBe('10|3');
+});

--- a/tests/refund_comments.test.js
+++ b/tests/refund_comments.test.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+const {execFileSync} = require('child_process');
+const os = require('os');
+
+const dbPath = path.join(os.tmpdir(), 'refund_test.sqlite');
+
+test('add and fetch refund comments', () => {
+  try { fs.unlinkSync(dbPath); } catch(e) {}
+  const env = {...process.env, DB_FILE: dbPath};
+  execFileSync('php', ['assets/cPhp/add_refund_comment.php'], {input: JSON.stringify({refund_id:1,user_id:2,comment:"hello"}), env});
+  const script = `$_GET['refund_id']=1; include '${path.resolve('assets/cPhp/get_refund_comments.php')}';`;
+  const out = execFileSync('php', ['-r', script], {env});
+  const rows = JSON.parse(out.toString());
+  expect(rows[0].comment).toBe('hello');
+});


### PR DESCRIPTION
## Summary
- load 17TRACK API key from settings
- manage bulk price tiers
- add inventory thresholds and stock logs
- support refund attachments and comments
- expand tests for new APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846821621fc832fa0e7b6d11b5a6c2a