### PR TITLE
Add environment bootstrap and dynamic settings

### DIFF
--- a/analytics.php
+++ b/analytics.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/assets/cPhp/add_refund_comment.php
+++ b/assets/cPhp/add_refund_comment.php
@@ -1,6 +1,22 @@
 <?php
 require_once __DIR__ . '/config/bootstrap.php';
 require_once __DIR__ . '/db.php';
+// Ensure refund_comments table exists if using WordPress DB
+if (isset($GLOBALS['wpdb'])) {
+    global $wpdb;
+    $table = $wpdb->prefix . 'refund_comments';
+    if (! $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table))) {
+        $wpdb->query("
+            CREATE TABLE {$table} (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                refund_id BIGINT NOT NULL,
+                user_id BIGINT NOT NULL,
+                comment TEXT NOT NULL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        ");
+    }
+}
 header('Content-Type: application/json; charset=utf-8');
 $raw = file_get_contents('php://input');
 if ($raw === '' && PHP_SAPI === 'cli') {

--- a/assets/cPhp/config/bootstrap.php
+++ b/assets/cPhp/config/bootstrap.php
@@ -1,6 +1,12 @@
 <?php
-use Dotenv\Dotenv;
-require_once __DIR__ . '/../../vendor/autoload.php';
-$dotenv = Dotenv::createImmutable(__DIR__ . '/../../');
-$dotenv->safeLoad();
+// Autoload and phpdotenv bootstrap
+$autoloadPath = __DIR__ . '/../../../vendor/autoload.php';
+if (file_exists($autoloadPath)) {
+    require_once $autoloadPath;
+    if (class_exists(\Dotenv\Dotenv::class)) {
+        $dotenv = \Dotenv\Dotenv::createImmutable(dirname($autoloadPath));
+        $dotenv->safeLoad();
+    }
+}
+// If autoload.php is missing, skip phpdotenv without error
 ?>

--- a/assets/cPhp/get_bulk_pricing.php
+++ b/assets/cPhp/get_bulk_pricing.php
@@ -1,6 +1,22 @@
 <?php
 require_once __DIR__ . '/config/bootstrap.php';
 require_once __DIR__ . '/db.php';
+// Ensure price_tiers table exists if using WordPress DB
+if (isset($GLOBALS['wpdb'])) {
+    global $wpdb;
+    $table = $wpdb->prefix . 'price_tiers';
+    if (! $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table))) {
+        $wpdb->query("
+            CREATE TABLE {$table} (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                product_id BIGINT NOT NULL,
+                min_qty INT NOT NULL,
+                max_qty INT NOT NULL,
+                unit_price DECIMAL(10,2) NOT NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        ");
+    }
+}
 header('Content-Type: application/json; charset=utf-8');
 $productId = isset($_GET['product_id']) ? (int)$_GET['product_id'] : 0;
 if ($productId) {

--- a/assets/cPhp/get_refund_comments.php
+++ b/assets/cPhp/get_refund_comments.php
@@ -1,6 +1,22 @@
 <?php
 require_once __DIR__ . '/config/bootstrap.php';
 require_once __DIR__ . '/db.php';
+// Ensure refund_comments table exists if using WordPress DB
+if (isset($GLOBALS['wpdb'])) {
+    global $wpdb;
+    $table = $wpdb->prefix . 'refund_comments';
+    if (! $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table))) {
+        $wpdb->query("
+            CREATE TABLE {$table} (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                refund_id BIGINT NOT NULL,
+                user_id BIGINT NOT NULL,
+                comment TEXT NOT NULL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        ");
+    }
+}
 header('Content-Type: application/json; charset=utf-8');
 $id = isset($_GET['refund_id']) ? (int)$_GET['refund_id'] : 0;
 if (!$id) { echo json_encode([]); exit; }

--- a/assets/cPhp/get_stock_log.php
+++ b/assets/cPhp/get_stock_log.php
@@ -1,6 +1,22 @@
 <?php
 require_once __DIR__ . '/config/bootstrap.php';
 require_once __DIR__ . '/db.php';
+// Ensure stock_log table exists if using WordPress DB
+if (isset($GLOBALS['wpdb'])) {
+    global $wpdb;
+    $table = $wpdb->prefix . 'stock_log';
+    if (! $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table))) {
+        $wpdb->query("
+            CREATE TABLE {$table} (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                product_id BIGINT NOT NULL,
+                change_qty INT NOT NULL,
+                reason TEXT NOT NULL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        ");
+    }
+}
 header('Content-Type: application/json; charset=utf-8');
 $id = isset($_GET['product_id']) ? (int)$_GET['product_id'] : 0;
 if (!$id) { echo json_encode([]); exit; }

--- a/assets/cPhp/update_bulk_pricing.php
+++ b/assets/cPhp/update_bulk_pricing.php
@@ -1,6 +1,22 @@
 <?php
 require_once __DIR__ . '/config/bootstrap.php';
 require_once __DIR__ . '/db.php';
+// Ensure price_tiers table exists if using WordPress DB
+if (isset($GLOBALS['wpdb'])) {
+    global $wpdb;
+    $table = $wpdb->prefix . 'price_tiers';
+    if (! $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table))) {
+        $wpdb->query("
+            CREATE TABLE {$table} (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                product_id BIGINT NOT NULL,
+                min_qty INT NOT NULL,
+                max_qty INT NOT NULL,
+                unit_price DECIMAL(10,2) NOT NULL
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        ");
+    }
+}
 header('Content-Type: application/json; charset=utf-8');
 $raw = file_get_contents('php://input');
 if ($raw === '' && PHP_SAPI === 'cli') {

--- a/assets/cPhp/update_product.php
+++ b/assets/cPhp/update_product.php
@@ -4,6 +4,22 @@ require_once __DIR__ . '/config/bootstrap.php';
 
 require_once(__DIR__ . '/master-api.php');  // defines $store_url, $consumer_key, $consumer_secret
 require_once(__DIR__ . '/db.php');
+// Ensure stock_log table exists if using WordPress DB
+if (isset($GLOBALS['wpdb'])) {
+    global $wpdb;
+    $table = $wpdb->prefix . 'stock_log';
+    if (! $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table))) {
+        $wpdb->query("
+            CREATE TABLE {$table} (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                product_id BIGINT NOT NULL,
+                change_qty INT NOT NULL,
+                reason TEXT NOT NULL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+        ");
+    }
+}
 
 // 1) Decode JSON payload (or fallback to $_POST)
 $raw  = file_get_contents('php://input');

--- a/assets/cPhp/update_settings.php
+++ b/assets/cPhp/update_settings.php
@@ -15,25 +15,27 @@ file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT));
 
 // ------------------------------------------------------------------
 // Also update the .env file with credentials from settings
-$envPath  = __DIR__ . '/../../.env';
-$envLines = file_exists($envPath) ? file($envPath, FILE_IGNORE_NEW_LINES) : [];
-$envMap   = [];
-foreach ($envLines as $line) {
-    if (strpos($line, '=') !== false) {
-        [$k, $v] = explode('=', $line, 2);
-        $envMap[$k] = $v;
+$envPath = __DIR__ . '/../../.env';
+$dotenvData = file_exists($envPath) ? file($envPath, FILE_IGNORE_NEW_LINES) : [];
+$updates = [
+    'WC_CONSUMER_KEY'    => $data['woocommerce_ck'],
+    'WC_CONSUMER_SECRET' => $data['woocommerce_cs'],
+    'STORE_URL'          => $data['store_url'],
+];
+foreach ($updates as $key => $val) {
+    $found = false;
+    foreach ($dotenvData as &$line) {
+        if (strpos($line, "{$key}=") === 0) {
+            $line = "{$key}=\"{$val}\"";
+            $found = true;
+            break;
+        }
+    }
+    if (! $found) {
+        $dotenvData[] = "{$key}=\"{$val}\"";
     }
 }
-
-$envMap['WC_CONSUMER_KEY']    = $data['woocommerce_ck'] ?? '';
-$envMap['WC_CONSUMER_SECRET'] = $data['woocommerce_cs'] ?? '';
-$envMap['STORE_URL']          = $data['store_url'] ?? '';
-
-$newEnv = '';
-foreach ($envMap as $k => $v) {
-    $newEnv .= $k . '=' . $v . PHP_EOL;
-}
-file_put_contents($envPath, $newEnv);
+file_put_contents($envPath, implode(PHP_EOL, $dotenvData));
 
 echo json_encode(['success' => true]);
 ?>

--- a/cancelled-orders.php
+++ b/cancelled-orders.php
@@ -1,3 +1,6 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
+?>
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/delivered-orders.php
+++ b/delivered-orders.php
@@ -1,5 +1,6 @@
 <?php
 // portal/delivered-orders.php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/factory-documents.php
+++ b/factory-documents.php
@@ -1,5 +1,6 @@
 <?php
 // portal/factory-documents.php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/in-transit-orders.php
+++ b/in-transit-orders.php
@@ -1,3 +1,6 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
+?>
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/index.php
+++ b/index.php
@@ -1,3 +1,6 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
+?>
 <!-- portal/index.php -->
 <!DOCTYPE html>
 <html lang="en">

--- a/inventory-management.php
+++ b/inventory-management.php
@@ -1,5 +1,6 @@
 <?php
 // portal/inventory-management.php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/invoices.php
+++ b/invoices.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/lead-times.php
+++ b/lead-times.php
@@ -1,5 +1,6 @@
 <?php
 // portal/lead-times.php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/logistics-orders.php
+++ b/logistics-orders.php
@@ -1,5 +1,6 @@
 <?php
 // portal/logistics-orders.php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/new-orders.php
+++ b/new-orders.php
@@ -1,3 +1,6 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
+?>
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/new-product-requests.php
+++ b/new-product-requests.php
@@ -1,5 +1,6 @@
 <?php
 // portal/new-product-requests.php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/on-hold-orders.php
+++ b/on-hold-orders.php
@@ -1,3 +1,6 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
+?>
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/orders.php
+++ b/orders.php
@@ -1,5 +1,6 @@
 <?php
 // portal/orders.php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/payment-terms.php
+++ b/payment-terms.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/pending-orders.php
+++ b/pending-orders.php
@@ -1,3 +1,6 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
+?>
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/product-management.php
+++ b/product-management.php
@@ -1,5 +1,6 @@
 <?php
 // portal/product-management.php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/product-requests.php
+++ b/product-requests.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/refund-dashboard.php
+++ b/refund-dashboard.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/refunded-orders.php
+++ b/refunded-orders.php
@@ -1,3 +1,6 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
+?>
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/returned-orders.php
+++ b/returned-orders.php
@@ -1,3 +1,6 @@
+<?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
+?>
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/settings.php
+++ b/settings.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/shipments.php
+++ b/shipments.php
@@ -2,6 +2,7 @@
 // portal/shipments.php
 
 // 1) Load your base URL constant
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>

--- a/supplier-pricing.php
+++ b/supplier-pricing.php
@@ -1,5 +1,6 @@
 <?php
 // portal/supplier-pricing.php
+require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
 $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>


### PR DESCRIPTION
## Summary
- unify autoload/`Dotenv` bootstrap
- initialize bootstrap on all PHP pages
- sync portal settings with `.env`
- prepare runtime table creation for custom tables

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684695707e1c832fb900a2d91affc378