### PR TITLE
Fix portal pages and AJAX flows

### DIFF
--- a/assets/cPhp/get_analytics.php
+++ b/assets/cPhp/get_analytics.php
@@ -1,0 +1,4 @@
+<?php
+require_once __DIR__ . '/config/bootstrap.php';
+require_once __DIR__ . '/get_dashboard_summary.php';
+?>

--- a/assets/cPhp/get_dashboard_summary.php
+++ b/assets/cPhp/get_dashboard_summary.php
@@ -42,6 +42,7 @@ $summary = [
     'pending'       => 0,
     'in_transit'    => 0,
     'delivered'     => 0,
+    'on_hold'       => 0,
     'refunded'      => 0,
     'revenue'       => 0.0,
     'top_sellers'   => [],  // will fill in step 5
@@ -87,6 +88,7 @@ foreach ($orders as $o) {
     if ($st === 'pending')     $summary['pending']++;
     if ($st === 'in-transit')  $summary['in_transit']++;
     if ($st === 'delivered')   $summary['delivered']++;
+    if ($st === 'on-hold')     $summary['on_hold']++;
     if ($st === 'refunded')    $summary['refunded']++;
 
     // Monthly revenue

--- a/assets/cPhp/get_top_sellers.php
+++ b/assets/cPhp/get_top_sellers.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__ . '/config/bootstrap.php';
+require_once __DIR__ . '/master-api.php';
+
+$per_page = 10;
+$period   = isset($_GET['period']) ? $_GET['period'] : 'yearly';
+$endpoint = $period === 'monthly' ? '/wp-json/wc/v3/reports/top_sellers?period=month&per_page=' : '/wp-json/wc/v3/reports/top_sellers?per_page=';
+$url = rtrim($store_url,'/').$endpoint.$per_page;
+$ch = curl_init($url);
+curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
+curl_setopt($ch,CURLOPT_USERPWD, "$consumer_key:$consumer_secret");
+$resp = curl_exec($ch);
+curl_close($ch);
+header('Content-Type: application/json; charset=utf-8');
+echo $resp ?: '[]';

--- a/assets/cPhp/update_supplier_price.php
+++ b/assets/cPhp/update_supplier_price.php
@@ -1,0 +1,22 @@
+<?php
+require_once __DIR__ . '/config/bootstrap.php';
+require_once __DIR__ . '/db.php';
+header('Content-Type: application/json; charset=utf-8');
+$data = json_decode(file_get_contents('php://input'), true) ?: $_POST;
+$id   = isset($data['id']) ? (int)$data['id'] : 0;
+$bulk = isset($data['bulk_price']) ? floatval($data['bulk_price']) : null;
+if (!$id) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing id']);
+    exit;
+}
+$stmt = $db->prepare('UPDATE supplier_prices SET bulk_price = :b WHERE id = :i');
+$stmt->bindValue(':b', $bulk);
+$stmt->bindValue(':i', $id, SQLITE3_INTEGER);
+$stmt->execute();
+if ($db->changes() === 0) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Record not found']);
+    exit;
+}
+echo json_encode(['success' => true]);

--- a/assets/js/cJs/analytics.js
+++ b/assets/js/cJs/analytics.js
@@ -80,19 +80,22 @@ $(function() {
       });
     }
 
-    if (data.chart1 && document.getElementById('chartMonth')) {
-      new Chart(document.getElementById('chartMonth'), {
-        type: 'bar',
-        data: {
-          labels: data.chart1.labels,
-          datasets: [{
-            label: 'Revenue',
-            data: data.chart1.revenue,
-            backgroundColor: '#42a5f5'
-          }]
-        },
-        options: { responsive: true }
-      });
-    }
+
+    $.getJSON(`${BASE_URL}/assets/cPhp/get_analytics.php?period=monthly`, month => {
+      if (month.chart1 && document.getElementById('chartMonth')) {
+        new Chart(document.getElementById('chartMonth'), {
+          type: 'bar',
+          data: {
+            labels: month.chart1.labels,
+            datasets: [{
+              label: 'Revenue',
+              data: month.chart1.revenue,
+              backgroundColor: '#42a5f5'
+            }]
+          },
+          options: { responsive: true }
+        });
+      }
+    });
   });
 });

--- a/assets/js/cJs/dashboard.js
+++ b/assets/js/cJs/dashboard.js
@@ -4,6 +4,7 @@ $(function() {
     $('#box-pending').text(data.pending);
     $('#box-in-transit').text(data.in_transit);
     $('#box-delivered').text(data.delivered);
+    $('#box-on-hold').text(data.on_hold || 0);
     $('#box-refunds').text(data.refunded);
     $('#box-low-stock').text(data.low_stock);
     $('#box-revenue').text(`AED ${data.revenue.toFixed(2)}`);
@@ -69,14 +70,13 @@ $(function() {
       });
     }
 
-    renderTop(data.top_sellers_yearly || data.top_sellers);
+    $.getJSON(`${BASE_URL}/assets/cPhp/get_top_sellers.php`, list => {
+      renderTop(list);
+    });
 
     $('#top-range').on('change', function() {
-      const list = (this.value === 'monthly'
-        ? (data.top_sellers_monthly || data.top_sellers)
-        : (data.top_sellers_yearly  || data.top_sellers)
-      );
-      renderTop(list);
+      const period = this.value;
+      $.getJSON(`${BASE_URL}/assets/cPhp/get_top_sellers.php?period=${period}`, renderTop);
     });
   });
 });

--- a/assets/js/cJs/lead-times.js
+++ b/assets/js/cJs/lead-times.js
@@ -6,6 +6,7 @@ $(function(){
   $('#leadForm').on('submit', function(e){
     e.preventDefault();
     const data = {
+      id: $('#lt_id').val() || 0,
       product: $('#lt_product').val(),
       supplier: $('#lt_supplier').val(),
       lead_time: $('#lt_time').val()
@@ -15,7 +16,7 @@ $(function(){
       url:`${BASE_URL}/assets/cPhp/add_lead_time.php`,
       data:JSON.stringify(data),
       contentType:'application/json',
-      success:() => { loadTimes(); this.reset(); }
+      success:() => { loadTimes(); $('#leadForm')[0].reset(); $('#lt_id').val(''); }
     });
   });
 });
@@ -24,7 +25,15 @@ function loadTimes(){
   $.getJSON(`${BASE_URL}/assets/cPhp/get_lead_times.php`, function(rows){
     const tbody = $('#timesBody').empty();
     rows.forEach(r => {
-      tbody.append(`<tr><td>${r.id}</td><td>${r.product}</td><td>${r.supplier}</td><td>${r.lead_time}</td><td>${r.last_updated}</td></tr>`);
+      tbody.append(`<tr data-id="${r.id}"><td>${r.id}</td><td>${r.product}</td><td>${r.supplier}</td><td>${r.lead_time}</td><td>${r.last_updated}</td><td><button class="btn btn-sm btn-secondary edit-time">Edit</button></td></tr>`);
     });
   });
 }
+
+$(document).on('click','.edit-time', function(){
+  const row = $(this).closest('tr');
+  $('#lt_id').val(row.data('id'));
+  $('#lt_product').val(row.children().eq(1).text());
+  $('#lt_supplier').val(row.children().eq(2).text());
+  $('#lt_time').val(row.children().eq(3).text());
+});

--- a/assets/js/cJs/logistics_orders.js
+++ b/assets/js/cJs/logistics_orders.js
@@ -19,6 +19,10 @@ $(function(){
     searchOrderId = this.value.trim();
     fetchLogisticsOrders(1);
   });
+
+  $('#refreshShipments').on('click', function(){
+    $.getJSON(`${BASE_URL}/assets/cPhp/update_tracking.php`, () => fetchLogisticsOrders(currentPage));
+  });
 });
 
 // Fetch orders currently in the "processing" state

--- a/assets/js/cJs/product-management.js
+++ b/assets/js/cJs/product-management.js
@@ -172,7 +172,13 @@ $('#editProductForm').submit(function(e){
   })
   .done(() => {
     bootstrap.Modal.getInstance($('#editProductModal')[0]).hide();
-    fetchProducts(currentPage);
+    const idx = allProducts.findIndex(p => p.id == payload.id);
+    if (idx >= 0) {
+      allProducts[idx] = { ...allProducts[idx], ...payload };
+      renderTable();
+    } else {
+      fetchProducts(currentPage);
+    }
   })
   .fail(xhr => {
     console.error('Update failed:', xhr.responseText);

--- a/assets/js/cJs/supplier-pricing.js
+++ b/assets/js/cJs/supplier-pricing.js
@@ -26,7 +26,28 @@ function loadPrices(){
   $.getJSON(`${BASE_URL}/assets/cPhp/get_supplier_prices.php`, function(rows){
     const tbody = $('#pricesBody').empty();
     rows.forEach(r => {
-      tbody.append(`<tr><td>${r.id}</td><td>${r.supplier}</td><td>${r.product}</td><td>${r.price}</td><td>${r.bulk_price||''}</td><td>${r.effective_date}</td></tr>`);
+      tbody.append(`
+        <tr>
+          <td>${r.id}</td>
+          <td>${r.supplier}</td>
+          <td>${r.product}</td>
+          <td>${r.price}</td>
+          <td>
+            <input type="number" step="0.01" class="form-control form-control-sm bulk-input" data-id="${r.id}" value="${r.bulk_price || ''}">
+          </td>
+          <td>${r.effective_date}</td>
+        </tr>`);
     });
   });
 }
+
+$(document).on('change','.bulk-input', function(){
+  const id   = $(this).data('id');
+  const bulk = $(this).val();
+  $.ajax({
+    method:'POST',
+    url:`${BASE_URL}/assets/cPhp/update_supplier_price.php`,
+    contentType:'application/json',
+    data: JSON.stringify({id, bulk_price: bulk})
+  });
+});

--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
+require_once __DIR__ . '/assets/cPhp/server-config.php';
 ?>
 <!-- portal/index.php -->
 <!DOCTYPE html>
@@ -73,6 +74,15 @@ require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
                 <div class="content">
                   <h6>Orders Delivered</h6>
                   <h3 id="box-delivered">Loading…</h3>
+                </div>
+              </div>
+            </div>
+            <div class="col-xl-3 col-lg-4 col-sm-6">
+              <div class="icon-card mb-30">
+                <div class="icon secondary"><i class="lni lni-pause"></i></div>
+                <div class="content">
+                  <h6>On Hold Orders</h6>
+                  <h3 id="box-on-hold">Loading…</h3>
                 </div>
               </div>
             </div>

--- a/inventory-management.php
+++ b/inventory-management.php
@@ -1,6 +1,7 @@
 <?php
 // portal/inventory-management.php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
+require_once __DIR__ . '/assets/cPhp/server-config.php';
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/lead-times.php
+++ b/lead-times.php
@@ -26,6 +26,7 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
         <div class="container-fluid">
           <h3 class="mb-3">Lead Time Tracking</h3>
           <form id="leadForm" class="row g-2 mb-3">
+            <input type="hidden" id="lt_id" />
             <div class="col-md-3"><input id="lt_product" class="form-control" placeholder="Product" required></div>
             <div class="col-md-3"><input id="lt_supplier" class="form-control" placeholder="Supplier" required></div>
             <div class="col-md-3"><input id="lt_time" class="form-control" placeholder="Lead Time (days)" required></div>
@@ -33,7 +34,7 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
           </form>
           <div class="table-responsive">
             <table class="table table-striped table-hover table-bordered">
-              <thead><tr><th>ID</th><th>Product</th><th>Supplier</th><th>Lead Time</th><th>Updated</th></tr></thead>
+              <thead><tr><th>ID</th><th>Product</th><th>Supplier</th><th>Lead Time</th><th>Updated</th><th></th></tr></thead>
               <tbody id="timesBody"></tbody>
             </table>
           </div>

--- a/new-product-requests.php
+++ b/new-product-requests.php
@@ -29,13 +29,13 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
       </header>
       <section class="section">
         <div class="container-fluid">
-          <h3 class="mb-3">New Product Requests</h3>
-          <form id="requestForm" class="row g-2 mb-3">
-            <div class="col-md-3"><input id="supplier" class="form-control" placeholder="Supplier" required></div>
-            <div class="col-md-3"><input id="product" class="form-control" placeholder="Product" required></div>
-            <div class="col-md-4"><input id="description" class="form-control" placeholder="Description"></div>
-            <div class="col-md-2"><button class="btn btn-primary w-100">Add</button></div>
-          </form>
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h3 class="mb-0">New Product Requests</h3>
+            <div>
+              <button id="newProductBtn" class="btn btn-primary btn-sm me-2">New Product</button>
+              <button id="priceChangeBtn" class="btn btn-secondary btn-sm">Price Change</button>
+            </div>
+          </div>
           <div class="table-responsive">
             <table class="table table-striped table-hover table-bordered" id="requestsTable">
               <thead>
@@ -51,24 +51,6 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
               <tbody id="requestsBody"></tbody>
             </table>
           </div>
-
-          <h5 class="mt-4 mb-2">Bulk Pricing</h5>
-          <input type="hidden" id="priceProductId" />
-          <div class="table-responsive mb-2">
-            <table class="table table-striped table-hover" id="tiersTable">
-              <thead>
-                <tr>
-                  <th>Min Qty</th>
-                  <th>Max Qty</th>
-                  <th>Unit Price</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
-          </div>
-          <button id="addTier" type="button" class="btn btn-sm btn-secondary me-2">Add Tier</button>
-          <button id="saveTiers" type="button" class="btn btn-sm btn-primary">Save Tiers</button>
 
           <!-- Tier Modal -->
           <div class="modal fade" id="tierModal" tabindex="-1" aria-hidden="true">
@@ -97,6 +79,62 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
                 <div class="modal-footer">
                   <button type="button" class="btn btn-primary" id="saveTierModal">Save</button>
                 </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Request Modal -->
+        <div class="modal fade" id="requestModal" tabindex="-1" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title">Submit Request</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+              </div>
+              <div class="modal-body">
+                <form id="requestForm">
+                  <div class="mb-3">
+                    <label class="form-label">Supplier</label>
+                    <input type="text" class="form-control" id="supplier" required />
+                  </div>
+                  <div class="mb-3">
+                    <label class="form-label">Product</label>
+                    <input type="text" class="form-control" id="product" required />
+                  </div>
+                  <div class="mb-3">
+                    <label class="form-label">Description</label>
+                    <textarea class="form-control" id="description"></textarea>
+                  </div>
+                </form>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-primary" id="saveRequest">Submit</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Pricing Modal -->
+        <div class="modal fade" id="pricingModal" tabindex="-1" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title">Bulk Pricing</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+              </div>
+              <div class="modal-body">
+                <input type="hidden" id="priceProductId" />
+                <table class="table table-striped table-hover" id="tiersTable">
+                  <thead>
+                    <tr><th>Min Qty</th><th>Max Qty</th><th>Unit Price</th><th></th></tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+                <button id="addTier" type="button" class="btn btn-sm btn-secondary">Add Tier</button>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-primary" id="saveTiers">Save</button>
               </div>
             </div>
           </div>

--- a/product-management.php
+++ b/product-management.php
@@ -1,6 +1,7 @@
 <?php
 // portal/product-management.php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
+require_once __DIR__ . '/assets/cPhp/server-config.php';
 ?>
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary
- add modals and buttons for product requests
- enable editing supplier prices and lead times
- update dashboard metrics and charts
- refresh logistics orders after tracking update
- load and update products and inventory via AJAX
- create helper endpoints for analytics and suppliers
- include server config in all main pages

## Testing
- `npm test` *(fails: TypeError: Converting circular structure to JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68469c4adc84832fa3c0e18575bdb2f1