### PR TITLE
Fix JS flows and add global BASE_URL

### DIFF
--- a/analytics.php
+++ b/analytics.php
@@ -1,7 +1,6 @@
 <?php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
-$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -14,6 +13,10 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
     <link rel="stylesheet" href="assets/css/lineicons.css" />
     <link rel="stylesheet" href="assets/css/materialdesignicons.min.css" />
     <link rel="stylesheet" href="assets/css/main.css" />
+    <script>
+      // Must appear before any other JS
+      window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+    </script>
   </head>
   <body>
     <div id="skeleton-loader"><div class="skeleton-block"></div></div>
@@ -53,7 +56,6 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
     <script src="assets/js/bootstrap.bundle.min.js"></script>
     <script src="assets/js/Chart.min.js"></script>
     <script src="assets/js/main.js"></script>
-    <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
     <script src="assets/js/cJs/analytics.js"></script>
   </body>
 </html>

--- a/assets/cPhp/get_on_hold_count.php
+++ b/assets/cPhp/get_on_hold_count.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . '/config/bootstrap.php';
+require_once __DIR__ . '/master-api.php';
+
+$url = rtrim($store_url, '/') . '/wp-json/wc/v3/orders?status=on-hold&per_page=1';
+$ch = curl_init($url);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HEADER         => true,
+    CURLOPT_USERPWD        => "$consumer_key:$consumer_secret",
+    CURLOPT_HTTPHEADER     => ['Content-Type: application/json']
+]);
+$response = curl_exec($ch);
+if ($response === false) {
+    http_response_code(500);
+    echo json_encode(['error' => curl_error($ch)]);
+    exit;
+}
+$hsize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+$header = substr($response, 0, $hsize);
+curl_close($ch);
+$count = 0;
+if (preg_match('/^X-WP-Total:\s*(\d+)/mi', $header, $m)) {
+    $count = (int)$m[1];
+}
+header('Content-Type: application/json; charset=utf-8');
+echo json_encode(['count' => $count]);
+exit;
+?>

--- a/assets/cPhp/get_shipments_summary.php
+++ b/assets/cPhp/get_shipments_summary.php
@@ -64,10 +64,12 @@ foreach ($orders as $o) {
     }
     $out[] = [
       'order_id'    => $o['id'],
+      'total'       => $o['total'],
       'provider'    => $prov,
       'tracking_no' => $track,
       'eta'         => $eta,
       'status'      => $o['status'],
+      'origin'      => $o['shipping']['country'] ?? '',
       'last_update' => $o['date_modified'],
     ];
 }

--- a/assets/js/cJs/dashboard.js
+++ b/assets/js/cJs/dashboard.js
@@ -4,7 +4,6 @@ $(function() {
     $('#box-pending').text(data.pending);
     $('#box-in-transit').text(data.in_transit);
     $('#box-delivered').text(data.delivered);
-    $('#box-on-hold').text(data.on_hold || 0);
     $('#box-refunds').text(data.refunded);
     $('#box-low-stock').text(data.low_stock);
     $('#box-revenue').text(`AED ${data.revenue.toFixed(2)}`);
@@ -21,6 +20,11 @@ $(function() {
     }
 
     renderNotifications(data.notifications);
+
+    // Fetch on-hold orders separately
+    $.getJSON(`${BASE_URL}/assets/cPhp/get_on_hold_count.php`, c => {
+      $('#box-on-hold').text(c.count || 0);
+    });
 
     function fetchTrackingNotifications() {
       $.getJSON(`${BASE_URL}/assets/cPhp/update_tracking.php`, res => {
@@ -70,13 +74,13 @@ $(function() {
       });
     }
 
-    $.getJSON(`${BASE_URL}/assets/cPhp/get_top_sellers.php`, list => {
+    $.getJSON(`${BASE_URL}/assets/cPhp/get_top_sellers.php?limit=10`, list => {
       renderTop(list);
     });
 
     $('#top-range').on('change', function() {
       const period = this.value;
-      $.getJSON(`${BASE_URL}/assets/cPhp/get_top_sellers.php?period=${period}`, renderTop);
+      $.getJSON(`${BASE_URL}/assets/cPhp/get_top_sellers.php?limit=10&period=${period}`, renderTop);
     });
   });
 });

--- a/assets/js/cJs/logistics_orders.js
+++ b/assets/js/cJs/logistics_orders.js
@@ -41,13 +41,11 @@ function fetchLogisticsOrders(page=1){
         $tb.append(`
           <tr>
             <td>#${o.order_id}</td>
-            <td>${formatDate(o.last_update)}</td>
+            <td>AED ${o.total}</td>
             <td>${o.status}</td>
-            <td>-</td>
-            <td>-</td>
             <td><button class="btn btn-sm btn-primary view-btn" data-id="${o.order_id}"><i class="lni lni-eye"></i></button></td>
             <td>${o.tracking_no || ''}</td>
-            <td>${o.provider || ''}</td>
+            <td>${o.origin || ''}</td>
           </tr>
         `);
       });

--- a/factory-documents.php
+++ b/factory-documents.php
@@ -2,7 +2,6 @@
 // portal/factory-documents.php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
-$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -14,7 +13,10 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
     <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
     <link rel="stylesheet" href="assets/css/lineicons.css" />
     <link rel="stylesheet" href="assets/css/main.css" />
-    <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+    <script>
+      // Must appear before any other JS
+      window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+    </script>
   </head>
   <body>
     <div id="skeleton-loader"><div class="skeleton-block"></div></div>

--- a/index.php
+++ b/index.php
@@ -22,6 +22,10 @@ require_once __DIR__ . '/assets/cPhp/server-config.php';
       /* small tweak so selects don’t shrink */
       .select-sm { min-width: 120px; }
     </style>
+    <script>
+      // Must appear before any other JS
+      window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+    </script>
   </head>
   <body>
     <div id="skeleton-loader"><div class="skeleton-block"></div></div>
@@ -177,9 +181,6 @@ require_once __DIR__ . '/assets/cPhp/server-config.php';
     <script src="assets/js/world-merc.js"></script>
     <script src="assets/js/polyfill.js"></script>
     <script src="assets/js/main.js"></script>
-    <script>
-      const BASE_URL = "<?php include 'assets/cPhp/server-config.php'; echo rtrim(PROJECT_BASE_URL, '/'); ?>";
-    </script>
     <script src="assets/js/cJs/dashboard.js"></script>
   </body>
 </html>

--- a/inventory-management.php
+++ b/inventory-management.php
@@ -23,6 +23,10 @@ require_once __DIR__ . '/assets/cPhp/server-config.php';
       td { white-space: nowrap; vertical-align: top; }
       .badge { font-size: .9em; }
     </style>
+    <script>
+      // Must appear before any other JS
+      window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+    </script>
   </head>
   <body>
     <div id="skeleton-loader"><div class="skeleton-block"></div></div>
@@ -156,14 +160,6 @@ require_once __DIR__ . '/assets/cPhp/server-config.php';
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="assets/js/bootstrap.bundle.min.js"></script>
     <script src="assets/js/main.js"></script>
-
-    <!-- Portal Base URL for AJAX -->
-    <script>
-      window.BASE_URL = "<?php
-        include 'assets/cPhp/server-config.php';
-        echo rtrim(PROJECT_BASE_URL, '/');
-      ?>";
-    </script>
 
     <!-- Page-specific JS -->
     <script src="assets/js/cJs/inventory-management.js"></script>

--- a/invoices.php
+++ b/invoices.php
@@ -1,7 +1,6 @@
 <?php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
-$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -15,7 +14,10 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
   <link rel="stylesheet" href="assets/css/lineicons.css" />
   <link rel="stylesheet" href="assets/css/materialdesignicons.min.css" />
   <link rel="stylesheet" href="assets/css/main.css" />
-  <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+  <script>
+    // Must appear before any other JS
+    window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+  </script>
 </head>
 <body>
   <div id="skeleton-loader"><div class="skeleton-block"></div></div>

--- a/lead-times.php
+++ b/lead-times.php
@@ -2,7 +2,6 @@
 // portal/lead-times.php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
-$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -14,7 +13,10 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
     <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
     <link rel="stylesheet" href="assets/css/lineicons.css" />
     <link rel="stylesheet" href="assets/css/main.css" />
-    <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+    <script>
+      // Must appear before any other JS
+      window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+    </script>
   </head>
   <body>
     <div id="skeleton-loader"><div class="skeleton-block"></div></div>

--- a/logistics-orders.php
+++ b/logistics-orders.php
@@ -2,7 +2,6 @@
 // portal/logistics-orders.php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
-$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -35,7 +34,10 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
       /* ... Add more .status-* classes as needed ... */
     </style>
     <!-- Provide BASE_URL constant for JS -->
-    <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+    <script>
+      // Must appear before any other JS
+      window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+    </script>
   </head>
   <body>
     <!-- ======== Preloader (optional) =========== -->
@@ -85,8 +87,6 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
                       <thead>
                         <tr>
                           <th><h6>Order #</h6></th>
-                          <th><h6>Date</h6></th>
-                          <th><h6>Status</h6></th>
                           <th><h6>Total</h6></th>
                           <th><h6>Export/Status</h6></th>
                           <th><h6>Actions</h6></th>

--- a/new-product-requests.php
+++ b/new-product-requests.php
@@ -2,7 +2,6 @@
 // portal/new-product-requests.php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
-$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -14,7 +13,10 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
     <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
     <link rel="stylesheet" href="assets/css/lineicons.css" />
     <link rel="stylesheet" href="assets/css/main.css" />
-    <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+    <script>
+      // Must appear before any other JS
+      window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+    </script>
   </head>
   <body>
     <div id="skeleton-loader"><div class="skeleton-block"></div></div>

--- a/payment-terms.php
+++ b/payment-terms.php
@@ -1,7 +1,6 @@
 <?php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
-$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -15,7 +14,10 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
   <link rel="stylesheet" href="assets/css/lineicons.css" />
   <link rel="stylesheet" href="assets/css/materialdesignicons.min.css" />
   <link rel="stylesheet" href="assets/css/main.css" />
-  <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+  <script>
+    // Must appear before any other JS
+    window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+  </script>
 </head>
 <body>
   <div id="skeleton-loader"><div class="skeleton-block"></div></div>

--- a/product-management.php
+++ b/product-management.php
@@ -25,6 +25,10 @@ require_once __DIR__ . '/assets/cPhp/server-config.php';
       img { border-radius: 4px; }
       .badge { font-size: .9em; }
     </style>
+    <script>
+      // Must appear before any other JS
+      window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+    </script>
   </head>
   <body>
     <div id="skeleton-loader"><div class="skeleton-block"></div></div>
@@ -172,14 +176,6 @@ require_once __DIR__ . '/assets/cPhp/server-config.php';
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="assets/js/bootstrap.bundle.min.js"></script>
     <script src="assets/js/main.js"></script>
-
-    <!-- BASE_URL (for AJAX paths) -->
-    <script>
-      window.BASE_URL = "<?php
-        include 'assets/cPhp/server-config.php';
-        echo rtrim(PROJECT_BASE_URL, '/');
-      ?>";
-    </script>
 
     <!-- Page JS -->
     <script src="assets/js/cJs/product-management.js"></script>

--- a/product-requests.php
+++ b/product-requests.php
@@ -1,7 +1,6 @@
 <?php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
-$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -15,7 +14,10 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
   <link rel="stylesheet" href="assets/css/lineicons.css" />
   <link rel="stylesheet" href="assets/css/materialdesignicons.min.css" />
   <link rel="stylesheet" href="assets/css/main.css" />
-  <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+  <script>
+    // Must appear before any other JS
+    window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+  </script>
 </head>
 <body>
   <div id="skeleton-loader"><div class="skeleton-block"></div></div>

--- a/refund-dashboard.php
+++ b/refund-dashboard.php
@@ -1,7 +1,6 @@
 <?php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
-$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -14,6 +13,10 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
   <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
   <link rel="stylesheet" href="assets/css/lineicons.css" />
   <link rel="stylesheet" href="assets/css/main.css" />
+  <script>
+    // Must appear before any other JS
+    window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+  </script>
 </head>
 <body>
   <div id="skeleton-loader"><div class="skeleton-block"></div></div>
@@ -69,7 +72,6 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="assets/js/bootstrap.bundle.min.js"></script>
   <script src="assets/js/main.js"></script>
-  <script> const BASE_URL = "<?= $BASE_URL ?>"; </script>
   <script src="assets/js/cJs/refund_requests.js"></script>
   <script src="assets/js/cJs/pagination.js"></script>
 </body>

--- a/settings.php
+++ b/settings.php
@@ -1,7 +1,6 @@
 <?php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
-$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -13,7 +12,10 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
   <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
   <link rel="stylesheet" href="assets/css/lineicons.css" />
   <link rel="stylesheet" href="assets/css/main.css" />
-  <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+  <script>
+    // Must appear before any other JS
+    window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+  </script>
 </head>
 <body>
   <div id="skeleton-loader"><div class="skeleton-block"></div></div>

--- a/supplier-pricing.php
+++ b/supplier-pricing.php
@@ -2,7 +2,6 @@
 // portal/supplier-pricing.php
 require_once __DIR__ . '/assets/cPhp/config/bootstrap.php';
 require_once __DIR__ . '/assets/cPhp/server-config.php';
-$BASE_URL = rtrim(PROJECT_BASE_URL, '/');
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -14,7 +13,10 @@ $BASE_URL = rtrim(PROJECT_BASE_URL, '/');
     <link rel="stylesheet" href="assets/css/bootstrap.min.css" />
     <link rel="stylesheet" href="assets/css/lineicons.css" />
     <link rel="stylesheet" href="assets/css/main.css" />
-    <script>const BASE_URL = "<?= $BASE_URL ?>";</script>
+    <script>
+      // Must appear before any other JS
+      window.BASE_URL = "<?php echo rtrim(PROJECT_BASE_URL, '/'); ?>";
+    </script>
   </head>
   <body>
     <div id="skeleton-loader"><div class="skeleton-block"></div></div>


### PR DESCRIPTION
## Summary
- add endpoint for on-hold order count
- show on-hold orders KPI and fix top sellers query
- improve logistics orders data and table
- inject BASE_URL variable globally and clean script tags

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a39e2f10832facecdaafaa86cb52